### PR TITLE
fix: docker usage with makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ dev-restart:
 
 dev-reset:
 	$(COMPOSE_DEV) down -v
+	rm -rf dist tsconfig.tsbuildinfo
 
 prod-up:
 	$(COMPOSE_PROD) up -d
@@ -124,7 +125,7 @@ db-reset:
 	$(COMPOSE_DEV) up -d
 
 clean:
-	rm -rf dist tsconfig.build.tsbuildinfo
+	rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo
 
 check:
 	docker build . --check

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "rootDir": "./src",
     "incremental": true,
     "skipLibCheck": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
This pull request updates the `Makefile` to improve consistency and thoroughness in cleaning up build artifacts. The key changes ensure that both `dev-reset` and `clean` targets remove all relevant TypeScript build info files and the `dist` directory.

Cleanup improvements:

* Updated the `dev-reset` target to also remove the `dist` directory and the `tsconfig.tsbuildinfo` file, ensuring a cleaner development environment reset.
* Enhanced the `clean` target to remove both `tsconfig.tsbuildinfo` and `tsconfig.build.tsbuildinfo` files, in addition to the `dist` directory, for a more comprehensive cleanup.