### PR TITLE
33 chorepeople renomear módulo users para people

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { UsersModule } from './users/users.module';
 import { PeopleModule } from './people/people.module';
 import { AddressesModule } from './addresses/addresses.module';
 import { EmployeesModule } from './employees/employees.module';

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { CouponsModule } from './coupons/coupons.module';
 import { ReviewsModule } from './reviews/reviews.module';
 import { OrdersModule } from './orders/orders.module';
 import { PaymentsModule } from './payments/payments.module';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 
 const nodeEnv = process.env.NODE_ENV ?? 'development';
 const isProduction = nodeEnv === 'production';
@@ -30,6 +31,7 @@ const isProduction = nodeEnv === 'production';
       password: process.env.POSTGRES_PASSWORD,
       database: process.env.POSTGRES_DB,
       autoLoadEntities: true,
+      namingStrategy: new SnakeNamingStrategy()
     }),
     PeopleModule,
     AddressesModule,

--- a/src/people/dtos/create-person.dto.ts
+++ b/src/people/dtos/create-person.dto.ts
@@ -1,1 +1,28 @@
-export class CreatePersonDto {}
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+/**
+ * Schema Zod para criação de uma Person.
+ *
+ * Esta issue (#33) implementa apenas o CRUD básico do módulo. As regras
+ * específicas dos endpoints de US02 (`/register` público) e US11 (cadastro
+ * pelo caixa, sem senha) serão refinadas em D2, em DTOs próprios. Aqui o
+ * DTO admite o caso geral: senha opcional, CPF/email obrigatórios.
+ *
+ * - CPF: 11 dígitos numéricos sem máscara (validação básica de formato; a
+ *   validação de dígitos verificadores não está no escopo desta entrega).
+ * - Email: formato válido, único no banco.
+ * - Senha: opcional aqui, mas quando presente exige mínimo de 8 caracteres
+ *   (alinhado com a US02).
+ */
+export const CreatePersonSchema = z.object({
+  cpf: z
+    .string()
+    .regex(/^\d{11}$/, 'CPF deve conter exatamente 11 dígitos numéricos'),
+  nome: z.string().min(1).max(120),
+  email: z.string().email().max(160),
+  telefone: z.string().max(20).optional(),
+  senha: z.string().min(8).max(72).optional(),
+});
+
+export class CreatePersonDto extends createZodDto(CreatePersonSchema) { }

--- a/src/people/dtos/update-person.dto.ts
+++ b/src/people/dtos/update-person.dto.ts
@@ -1,0 +1,11 @@
+import { createZodDto } from 'nestjs-zod';
+import { CreatePersonSchema } from './create-person.dto';
+
+/**
+ * Schema de atualização: todos os campos opcionais, exceto o CPF, que não
+ * pode ser alterado (é a PK). O CPF vai pela URL no PATCH, não pelo body,
+ * então é removido do schema do body.
+ */
+export const UpdatePersonSchema = CreatePersonSchema.omit({ cpf: true }).partial();
+
+export class UpdatePersonDto extends createZodDto(UpdatePersonSchema) {}

--- a/src/people/entities/person.entity.ts
+++ b/src/people/entities/person.entity.ts
@@ -1,1 +1,42 @@
-export class PersonEntity {}
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+/**
+ * Entity Person.
+ *
+ * Mapeia a tabela `person` no banco (gerada via SnakeNamingStrategy a partir
+ * do nome da classe). É a entidade base de identidade do sistema, usada tanto
+ * por clientes quanto, via especialização 1:1 (futuro módulo `employees`),
+ * por funcionários.
+ *
+ * Decisões de modelagem (ver CONTEXT.md):
+ * - PK: CPF (string de 11 dígitos sem formatação). Permite cadastro sem CPF
+ *   pelo caixa não é suportado nesta versão — clientes sem CPF são tratados
+ *   em iteração posterior (US11 cobre apenas o caixa criando com dados básicos).
+ * - `email` é único — usado para login.
+ * - `senha` é nullable: clientes cadastrados pelo caixa (US11) entram sem
+ *   senha e completam o cadastro depois (definindo a senha em fluxo separado).
+ * - Nomes de coluna em português (alinhamento com o domínio de negócio).
+ */
+@Entity()
+export class Person {
+  @PrimaryColumn({ type: 'varchar', length: 11 })
+  cpf: string;
+
+  @Column({ type: 'varchar', length: 120 })
+  nome: string;
+
+  @Column({ type: 'varchar', length: 160, unique: true })
+  email: string;
+
+  @Column({ type: 'varchar', length: 20, nullable: true })
+  telefone: string | null;
+
+  /**
+   * Hash bcrypt da senha. Nunca a senha em texto puro.
+   * Pode ser nula em casos onde o cadastro foi feito pelo caixa (US11) e o
+   * cliente ainda não definiu uma senha. Pessoas sem senha não conseguem
+   * fazer login (verificação no AuthService, em D0).
+   */
+  @Column({ type: 'varchar', length: 120, nullable: true })
+  senha: string | null;
+}

--- a/src/people/interfaces/person.interface.interface.ts
+++ b/src/people/interfaces/person.interface.interface.ts
@@ -1,1 +1,0 @@
-export interface PersonInterface {}

--- a/src/people/interfaces/person.interface.ts
+++ b/src/people/interfaces/person.interface.ts
@@ -1,0 +1,10 @@
+import { Person } from '../entities/person.entity';
+
+/**
+ * Projeção de Person sem o campo `senha`.
+ *
+ * Toda resposta de endpoint que envolva Person deve serializar para este
+ * tipo, garantindo que o hash da senha nunca vaze. O service expõe um helper
+ * `stripPassword(person) → IPersonSafe` para isso.
+ */
+export type IPersonSafe = Omit<Person, 'senha'>;

--- a/src/people/people.controller.ts
+++ b/src/people/people.controller.ts
@@ -1,4 +1,95 @@
-import { Controller } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+import { CreatePersonDto } from './dtos/create-person.dto';
+import { UpdatePersonDto } from './dtos/update-person.dto';
+import { PeopleService } from './people.service';
 
+/**
+ * Schema de paginação local. Será movido para `src/common/` em D2, quando
+ * mais módulos passarem a reusá-lo. `z.coerce.number()` é importante porque
+ * query params chegam sempre como string.
+ */
+const PaginationSchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(20),
+});
+class PaginationDto extends createZodDto(PaginationSchema) { }
+
+@ApiTags('people')
 @Controller('people')
-export class PeopleController {}
+export class PeopleController {
+  constructor(private readonly peopleService: PeopleService) { }
+
+  /**
+   * IMPORTANTE: este endpoint é o CRUD genérico de pessoas, sem guard nesta
+   * issue (#33). A versão pública para auto-cadastro de cliente
+   * (`POST /people/register`) e o cadastro restrito ao caixa (`POST /people`
+   * com guard) entram na issue de D2.
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Cria uma nova pessoa (CRUD básico)' })
+  @ApiResponse({ status: 201, description: 'Pessoa criada com sucesso' })
+  @ApiResponse({ status: 400, description: 'Payload inválido' })
+  @ApiResponse({ status: 409, description: 'CPF ou email já cadastrado' })
+  create(@Body() dto: CreatePersonDto) {
+    return this.peopleService.create(dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Lista pessoas com paginação' })
+  @ApiQuery({ name: 'page', required: false, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, example: 20 })
+  @ApiResponse({ status: 200, description: 'Lista paginada de pessoas' })
+  findAll(@Query() query: PaginationDto) {
+    return this.peopleService.findAll(query.page, query.limit);
+  }
+
+  @Get(':cpf')
+  @ApiOperation({ summary: 'Busca uma pessoa por CPF' })
+  @ApiParam({ name: 'cpf', description: 'CPF (11 dígitos sem máscara)' })
+  @ApiResponse({ status: 200, description: 'Pessoa encontrada' })
+  @ApiResponse({ status: 404, description: 'Pessoa não encontrada' })
+  findOne(@Param('cpf') cpf: string) {
+    return this.peopleService.findOne(cpf);
+  }
+
+  @Patch(':cpf')
+  @ApiOperation({ summary: 'Atualiza dados de uma pessoa' })
+  @ApiParam({ name: 'cpf', description: 'CPF (11 dígitos sem máscara)' })
+  @ApiResponse({ status: 200, description: 'Pessoa atualizada' })
+  @ApiResponse({ status: 404, description: 'Pessoa não encontrada' })
+  @ApiResponse({ status: 409, description: 'Email já cadastrado por outra pessoa' })
+  update(@Param('cpf') cpf: string, @Body() dto: UpdatePersonDto) {
+    return this.peopleService.update(cpf, dto);
+  }
+
+  @Delete(':cpf')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remove uma pessoa' })
+  @ApiParam({ name: 'cpf', description: 'CPF (11 dígitos sem máscara)' })
+  @ApiResponse({ status: 204, description: 'Pessoa removida' })
+  @ApiResponse({ status: 404, description: 'Pessoa não encontrada' })
+  remove(@Param('cpf') cpf: string) {
+    return this.peopleService.remove(cpf);
+  }
+}

--- a/src/people/people.module.ts
+++ b/src/people/people.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Person } from './entities/person.entity';
 import { PeopleController } from './people.controller';
 import { PeopleService } from './people.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Person])],
   controllers: [PeopleController],
-  providers: [PeopleService]
+  providers: [PeopleService],
+  // Exporta o service para que `auth` (D0) e `employees` (D2) consigam usá-lo.
+  exports: [PeopleService],
 })
 export class PeopleModule {}

--- a/src/people/people.service.spec.ts
+++ b/src/people/people.service.spec.ts
@@ -1,0 +1,188 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { PeopleService } from './people.service';
+import { Person } from './entities/person.entity';
+
+const mockPerson: Person = {
+  cpf: '12345678901',
+  nome: 'João Silva',
+  email: 'joao@email.com',
+  telefone: null,
+  senha: 'hash_bcrypt_placeholder',
+};
+
+const uniqueViolationError = new QueryFailedError('INSERT', [], {
+  code: '23505',
+  message: 'unique constraint violation',
+} as unknown as Error);
+
+describe('PeopleService', () => {
+  let service: PeopleService;
+  let repo: jest.Mocked<Repository<Person>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PeopleService,
+        {
+          provide: getRepositoryToken(Person),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            findOne: jest.fn(),
+            findAndCount: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(PeopleService);
+    repo = module.get(getRepositoryToken(Person));
+  });
+
+  describe('create', () => {
+    it('cria pessoa e retorna sem o campo senha', async () => {
+      repo.create.mockReturnValue(mockPerson);
+      repo.save.mockResolvedValue(mockPerson);
+
+      const result = await service.create({
+        cpf: mockPerson.cpf,
+        nome: mockPerson.nome,
+        email: mockPerson.email,
+      });
+
+      expect(result).not.toHaveProperty('senha');
+      expect(result.cpf).toBe(mockPerson.cpf);
+      expect(result.nome).toBe(mockPerson.nome);
+      expect(result.email).toBe(mockPerson.email);
+    });
+
+    it('lança ConflictException quando CPF ou email já existe', async () => {
+      repo.create.mockReturnValue(mockPerson);
+      repo.save.mockRejectedValue(uniqueViolationError);
+
+      await expect(
+        service.create({ cpf: mockPerson.cpf, nome: mockPerson.nome, email: mockPerson.email }),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('repropaga erros que não são violação de unicidade', async () => {
+      repo.create.mockReturnValue(mockPerson);
+      repo.save.mockRejectedValue(new Error('connection lost'));
+
+      await expect(
+        service.create({ cpf: mockPerson.cpf, nome: mockPerson.nome, email: mockPerson.email }),
+      ).rejects.toThrow('connection lost');
+    });
+  });
+
+  describe('findAll', () => {
+    it('retorna lista paginada sem o campo senha em nenhum item', async () => {
+      repo.findAndCount.mockResolvedValue([[mockPerson], 1]);
+
+      const result = await service.findAll(1, 10);
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).not.toHaveProperty('senha');
+      expect(result.meta).toEqual({ page: 1, limit: 10, total: 1, totalPages: 1 });
+    });
+
+    it('calcula totalPages corretamente', async () => {
+      const pessoas = Array.from({ length: 3 }, (_, i) => ({ ...mockPerson, cpf: `0000000000${i}` }));
+      repo.findAndCount.mockResolvedValue([pessoas, 25]);
+
+      const result = await service.findAll(1, 10);
+
+      expect(result.meta.totalPages).toBe(3);
+    });
+
+    it('retorna totalPages 1 quando não há registros', async () => {
+      repo.findAndCount.mockResolvedValue([[], 0]);
+
+      const result = await service.findAll(1, 10);
+
+      expect(result.meta.totalPages).toBe(1);
+      expect(result.data).toHaveLength(0);
+    });
+  });
+
+  describe('findOne', () => {
+    it('retorna pessoa sem o campo senha quando CPF existe', async () => {
+      repo.findOne.mockResolvedValue(mockPerson);
+
+      const result = await service.findOne(mockPerson.cpf);
+
+      expect(result).not.toHaveProperty('senha');
+      expect(result.cpf).toBe(mockPerson.cpf);
+    });
+
+    it('lança NotFoundException quando CPF não existe', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne('00000000000')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('atualiza e retorna pessoa sem o campo senha', async () => {
+      const updated: Person = { ...mockPerson, nome: 'João Atualizado' };
+      repo.findOne.mockResolvedValue(mockPerson);
+      repo.save.mockResolvedValue(updated);
+
+      const result = await service.update(mockPerson.cpf, { nome: 'João Atualizado' });
+
+      expect(result).not.toHaveProperty('senha');
+      expect(result.nome).toBe('João Atualizado');
+    });
+
+    it('lança NotFoundException quando CPF não existe', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(service.update('00000000000', { nome: 'X' })).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('lança ConflictException quando email já pertence a outra pessoa', async () => {
+      repo.findOne.mockResolvedValue(mockPerson);
+      repo.save.mockRejectedValue(uniqueViolationError);
+
+      await expect(
+        service.update(mockPerson.cpf, { email: 'outro@email.com' }),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+  });
+
+  describe('remove', () => {
+    it('remove sem erros quando CPF existe', async () => {
+      repo.delete.mockResolvedValue({ affected: 1, raw: [] });
+
+      await expect(service.remove(mockPerson.cpf)).resolves.toBeUndefined();
+    });
+
+    it('lança NotFoundException quando CPF não existe', async () => {
+      repo.delete.mockResolvedValue({ affected: 0, raw: [] });
+
+      await expect(service.remove('00000000000')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('findByEmailWithPassword', () => {
+    it('retorna pessoa COM o campo senha (uso interno do AuthService)', async () => {
+      repo.findOne.mockResolvedValue(mockPerson);
+
+      const result = await service.findByEmailWithPassword(mockPerson.email);
+
+      expect(result).toHaveProperty('senha');
+    });
+
+    it('retorna null quando email não existe', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      const result = await service.findByEmailWithPassword('nao@existe.com');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/people/people.service.ts
+++ b/src/people/people.service.ts
@@ -1,4 +1,135 @@
-import { Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
+import { CreatePersonDto } from './dtos/create-person.dto';
+import { UpdatePersonDto } from './dtos/update-person.dto';
+import { Person } from './entities/person.entity';
+import { IPersonSafe } from './interfaces/person.interface';
+
+/**
+ * Código de erro do Postgres para violação de UNIQUE constraint.
+ * Usado para mapear duplicatas de CPF/email para HTTP 409.
+ */
+const PG_UNIQUE_VIOLATION = '23505';
 
 @Injectable()
-export class PeopleService {}
+export class PeopleService {
+  constructor(
+    @InjectRepository(Person)
+    private readonly peopleRepository: Repository<Person>,
+  ) { }
+
+  /**
+   * Remove o campo `senha` antes de devolver uma Person.
+   * TODA resposta de endpoint deve passar por aqui.
+   */
+  private stripPassword(person: Person): IPersonSafe {
+    const { senha: _ignored, ...safe } = person;
+    return safe;
+  }
+
+  async create(dto: CreatePersonDto): Promise<IPersonSafe> {
+    // TODO(#34): aplicar hash bcrypt em `dto.senha` antes de persistir.
+    // Esta issue (#33) implementa apenas o CRUD; o hashing entra na issue
+    // seguinte do D0 ("feat(people): aplicar hash bcrypt em senhas").
+    const person = this.peopleRepository.create({
+      cpf: dto.cpf,
+      nome: dto.nome,
+      email: dto.email,
+      telefone: dto.telefone ?? null,
+      senha: dto.senha ?? null,
+    });
+
+    try {
+      const saved = await this.peopleRepository.save(person);
+      return this.stripPassword(saved);
+    } catch (err) {
+      if (
+        err instanceof QueryFailedError &&
+        (err.driverError as { code?: string })?.code === PG_UNIQUE_VIOLATION
+      ) {
+        // O detalhe do erro do PG indica qual constraint foi violada.
+        // Em vez de parsear a string, devolvemos uma mensagem genérica e
+        // deixamos o cliente lidar.
+        throw new ConflictException(
+          'CPF ou email já cadastrado',
+        );
+      }
+      throw err;
+    }
+  }
+
+  async findAll(
+    page: number,
+    limit: number,
+  ): Promise<{
+    data: IPersonSafe[];
+    meta: { page: number; limit: number; total: number; totalPages: number };
+  }> {
+    const [rows, total] = await this.peopleRepository.findAndCount({
+      skip: (page - 1) * limit,
+      take: limit,
+      order: { nome: 'ASC' },
+    });
+
+    return {
+      data: rows.map((p) => this.stripPassword(p)),
+      meta: {
+        page,
+        limit,
+        total,
+        totalPages: Math.max(1, Math.ceil(total / limit)),
+      },
+    };
+  }
+
+  async findOne(cpf: string): Promise<IPersonSafe> {
+    const person = await this.peopleRepository.findOne({ where: { cpf } });
+    if (!person) {
+      throw new NotFoundException(`Pessoa com CPF ${cpf} não encontrada`);
+    }
+    return this.stripPassword(person);
+  }
+
+  async update(cpf: string, dto: UpdatePersonDto): Promise<IPersonSafe> {
+    const person = await this.peopleRepository.findOne({ where: { cpf } });
+    if (!person) {
+      throw new NotFoundException(`Pessoa com CPF ${cpf} não encontrada`);
+    }
+
+    // TODO(#34): se `dto.senha` vier preenchida, aplicar bcrypt antes de persistir.
+    Object.assign(person, dto);
+
+    try {
+      const saved = await this.peopleRepository.save(person);
+      return this.stripPassword(saved);
+    } catch (err) {
+      if (
+        err instanceof QueryFailedError &&
+        (err.driverError as { code?: string })?.code === PG_UNIQUE_VIOLATION
+      ) {
+        throw new ConflictException('Email já cadastrado por outra pessoa');
+      }
+      throw err;
+    }
+  }
+
+  async remove(cpf: string): Promise<void> {
+    const result = await this.peopleRepository.delete({ cpf });
+    if (result.affected === 0) {
+      throw new NotFoundException(`Pessoa com CPF ${cpf} não encontrada`);
+    }
+  }
+
+  /**
+   * Busca interna por email. Retorna a Person COM senha — uso restrito ao
+   * AuthService para validação de login. Não exportar via controller.
+   */
+  async findByEmailWithPassword(email: string): Promise<Person | null> {
+    return this.peopleRepository.findOne({ where: { email } });
+  }
+}


### PR DESCRIPTION
This pull request implements the full CRUD for the "people" module, introducing entity modeling, DTOs with validation, service logic, controller endpoints, and comprehensive tests. The design ensures sensitive data like password hashes are never exposed via API responses, and provides robust validation and error handling for unique constraints (CPF and email). The changes also add TypeORM integration and pagination, setting the foundation for future expansions (like authentication and employee specialization).

**Key changes:**

### People Module: Entity, DTOs, and Interfaces

* Created the `Person` entity in `person.entity.ts`, mapping the domain model to the database with proper constraints (CPF as PK, unique email, nullable password for cashier-created users).
* Added DTOs using Zod schemas for creation (`CreatePersonDto`) and update (`UpdatePersonDto`), enforcing validation rules for CPF, email, and password. [[1]](diffhunk://#diff-3c969a958c6d41b2bf043ff56c73c292d0da4435f1f1ed7934f9fd15eee06d42L1-R28) [[2]](diffhunk://#diff-e082a0c48aeda76f95ff5678559bc111ba58c7e4fbc612d4714f2609f0bb78a9R1-R11)
* Introduced the `IPersonSafe` type to represent a person without the password field, ensuring that password hashes are never leaked in API responses.

### Service Logic and Error Handling

* Implemented `PeopleService` with methods for create, read (single and paginated), update, and delete, including error handling for unique constraint violations and not found cases. Added a helper to strip passwords from responses and an internal method to fetch by email with password (for future authentication use).
* Provided comprehensive unit tests for all service methods, covering success and error cases, including unique constraint violations and not found scenarios.

### Controller and API Endpoints

* Built the `PeopleController` exposing CRUD endpoints, with OpenAPI decorators for documentation, and implemented pagination for list queries.
* Added a local pagination DTO/schema (to be moved to a common location in the future).

### Module Integration and TypeORM Configuration

* Registered the `Person` entity in the module, exported the service for use in other modules (like authentication), and integrated TypeORM with the `SnakeNamingStrategy` for consistent database naming. [[1]](diffhunk://#diff-3ef47ce5cc339a576e523090066bfaae68568e01a1b1143bf631283273261317R2-R12) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R15) [[3]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R34)
* Removed unused files/interfaces and cleaned up imports. [[1]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8L4) [[2]](diffhunk://#diff-1c29901f02cec2d77aa414db31fbab437d0fde2cf9541889797f159fb3b056d9L1)

---

**References:**  
Entity, DTOs, and Interfaces: [[1]](diffhunk://#diff-81eaec1718d2273bf4c29af2dab313cdfb99c7d1c95245e9950703f6171cb722L1-R42) [[2]](diffhunk://#diff-3c969a958c6d41b2bf043ff56c73c292d0da4435f1f1ed7934f9fd15eee06d42L1-R28) [[3]](diffhunk://#diff-e082a0c48aeda76f95ff5678559bc111ba58c7e4fbc612d4714f2609f0bb78a9R1-R11) [[4]](diffhunk://#diff-d32314ed1615ef4647db32464f423ee47d054695945ff9f476b4889247ad4a9dR1-R10)  
Service Logic and Tests: [[1]](diffhunk://#diff-8de428a6e2dbbbb4739679ac34122a2e69e0d1348ac7262858b8a55919345cc5L1-R135) [[2]](diffhunk://#diff-db69287e39f88cf5424f2021764d3fbc07e0ce237b3138d23c0f134dada1b3d5R1-R188)  
Controller and Endpoints:  
Module/TypeORM Integration: [[1]](diffhunk://#diff-3ef47ce5cc339a576e523090066bfaae68568e01a1b1143bf631283273261317R2-R12) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R15) [[3]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R34)  
Cleanup: [[1]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8L4) [[2]](diffhunk://#diff-1c29901f02cec2d77aa414db31fbab437d0fde2cf9541889797f159fb3b056d9L1)