### PR TITLE
37 featauth configurar addbearerauth no swagger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Documentos antigos do projeto e issues podem mencionar decorators do
 
 ```typescript
 export enum Role {
+  CLIENTE = 'cliente',
   CAIXA = 'caixa',
   VENDEDOR = 'vendedor',
   GERENTE = 'gerente',
@@ -104,7 +105,8 @@ export enum Role {
 }
 ```
 
-Hierarquia (cada nível inclui o anterior):
+`CLIENTE` é role de acesso externo — qualquer `Person` sem vínculo com `Employee`.
+Hierarquia de funcionários (cada nível inclui o anterior):
 
 - `caixa`: registro de vendas, associar vendedores
 - `vendedor`: + participação em ranking e comissão

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SERVICE := api
 export DOCKER_BUILDKIT := 1
 export COMPOSE_DOCKER_CLI_BUILD := 1
 
-.PHONY: help env-setup install dev lint test build start \
+.PHONY: help env-setup gen-secrets install dev lint test build start \
 	dev-up dev-down dev-logs dev-logs-once dev-shell dev-build dev-rebuild dev-restart dev-reset \
 	prod-up prod-down prod-logs prod-build prod-rebuild \
 	db-shell db-reset \
@@ -45,6 +45,7 @@ help:
 	@echo "  make db-reset         Apaga apenas o volume do postgres (mantem cache de deps)"
 	@echo ""
 	@echo "Utilidades:"
+	@echo "  make gen-secrets      Gera JWT_SECRET aleatorio nos arquivos .env"
 	@echo "  make clean            Remove artefatos locais de build"
 	@echo "  make check            Verifica se o Dockerfile esta correto"
 
@@ -53,6 +54,20 @@ env-setup:
 	cp -n .env.production.example .env.production || true
 	@echo "Arquivos .env.development e .env.production criados (se ainda nao existiam)."
 	@echo "Edite-os com os valores reais antes de subir o ambiente."
+	@echo "Execute 'make gen-secrets' para gerar o JWT_SECRET automaticamente."
+
+gen-secrets:
+	$(eval SECRET := $(shell openssl rand -base64 32))
+	@for env_file in .env.development .env.production; do \
+		if [ -f $$env_file ]; then \
+			if grep -q "^JWT_SECRET=" $$env_file; then \
+				sed -i "s|^JWT_SECRET=.*|JWT_SECRET=$(SECRET)|" $$env_file; \
+			else \
+				echo "JWT_SECRET=$(SECRET)" >> $$env_file; \
+			fi; \
+			echo "JWT_SECRET atualizado em $$env_file"; \
+		fi; \
+	done
 
 install:
 	pnpm install

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { ReviewsModule } from './reviews/reviews.module';
 import { OrdersModule } from './orders/orders.module';
 import { PaymentsModule } from './payments/payments.module';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+import { AuthModule } from './auth/auth.module';
 
 const nodeEnv = process.env.NODE_ENV ?? 'development';
 const isProduction = nodeEnv === 'production';
@@ -44,6 +45,7 @@ const isProduction = nodeEnv === 'production';
     ReviewsModule,
     OrdersModule,
     PaymentsModule,
+    AuthModule,
   ],
 })
 export class AppModule { }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Post, Body, HttpCode } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { AuthService } from './auth.service';
+import { LoginDto } from './dtos/login.dto';
+
+@ApiTags('auth')
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('login')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Autentica um usuário e retorna um JWT' })
+  @ApiResponse({
+    status: 200,
+    description: 'Login bem-sucedido',
+    schema: {
+      type: 'object',
+      properties: {
+        access_token: { type: 'string' },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Email ou senha inválidos',
+  })
+  async login(@Body() dto: LoginDto): Promise<{ access_token: string }> {
+    return this.authService.login(dto);
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Person } from '../people/entities/person.entity';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { JwtStrategy } from './strategies/jwt.strategy';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Person]),
+    PassportModule,
+    JwtModule.register({
+      secret: process.env.JWT_SECRET,
+      signOptions: { expiresIn: '24h' },
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy],
+  exports: [JwtStrategy, PassportModule],
+})
+export class AuthModule {}

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,190 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { JwtService } from '@nestjs/jwt';
+import { UnauthorizedException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import { Repository } from 'typeorm';
+import { AuthService } from './auth.service';
+import { Person } from '../people/entities/person.entity';
+import { LoginDto } from './dtos/login.dto';
+import { Role } from '../common/enums/role.enum';
+
+jest.mock('bcrypt');
+
+const mockPerson: Person = {
+  cpf: '12345678901',
+  nome: 'João Silva',
+  email: 'joao@email.com',
+  telefone: null,
+  senha: '$2b$10$hashedpassword123456789',
+};
+
+const mockJwtToken =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwMSIsImVtYWlsIjoiam9hb0BlbWFpbC5jb20iLCJyb2xlIjoidXNlciIsImlhdCI6MTU2NzgwMDAwMCwiZXhwIjoxNTY3ODg2NDAwfQ.signature';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let personRepo: jest.Mocked<Repository<Person>>;
+  let jwtService: jest.Mocked<JwtService>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        {
+          provide: getRepositoryToken(Person),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: JwtService,
+          useValue: {
+            sign: jest.fn().mockReturnValue(mockJwtToken),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(AuthService);
+    personRepo = module.get(getRepositoryToken(Person));
+    jwtService = module.get(JwtService);
+  });
+
+  describe('login', () => {
+    it('retorna access_token quando credenciais são válidas', async () => {
+      personRepo.findOne.mockResolvedValue(mockPerson);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const loginDto: LoginDto = {
+        email: mockPerson.email,
+        senha: 'senha123',
+      };
+
+      const result = await service.login(loginDto);
+
+      expect(result).toHaveProperty('access_token');
+      expect(result.access_token).toBe(mockJwtToken);
+    });
+
+    it('gera JWT com payload contendo sub (CPF), email e role', async () => {
+      personRepo.findOne.mockResolvedValue(mockPerson);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const loginDto: LoginDto = {
+        email: mockPerson.email,
+        senha: 'senha123',
+      };
+
+      await service.login(loginDto);
+
+      expect(jwtService.sign).toHaveBeenCalledWith({
+        sub: mockPerson.cpf,
+        email: mockPerson.email,
+        role: Role.CLIENTE,
+      });
+    });
+
+    it('lança UnauthorizedException quando email não existe', async () => {
+      personRepo.findOne.mockResolvedValue(null);
+
+      const loginDto: LoginDto = {
+        email: 'naoexiste@email.com',
+        senha: 'senha123',
+      };
+
+      await expect(service.login(loginDto)).rejects.toBeInstanceOf(UnauthorizedException);
+      await expect(service.login(loginDto)).rejects.toThrow('Email ou senha inválidos');
+    });
+
+    it('lança UnauthorizedException quando senha está vazia (NULL)', async () => {
+      const personWithoutPassword: Person = {
+        ...mockPerson,
+        senha: null,
+      };
+      personRepo.findOne.mockResolvedValue(personWithoutPassword);
+
+      const loginDto: LoginDto = {
+        email: mockPerson.email,
+        senha: 'qualquer_senha',
+      };
+
+      await expect(service.login(loginDto)).rejects.toBeInstanceOf(UnauthorizedException);
+      await expect(service.login(loginDto)).rejects.toThrow('Email ou senha inválidos');
+    });
+
+    it('lança UnauthorizedException quando senha é incorreta', async () => {
+      personRepo.findOne.mockResolvedValue(mockPerson);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+      const loginDto: LoginDto = {
+        email: mockPerson.email,
+        senha: 'senhaerrada',
+      };
+
+      await expect(service.login(loginDto)).rejects.toBeInstanceOf(UnauthorizedException);
+      await expect(service.login(loginDto)).rejects.toThrow('Email ou senha inválidos');
+    });
+
+    it('valida senha com bcrypt.compare', async () => {
+      personRepo.findOne.mockResolvedValue(mockPerson);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const loginDto: LoginDto = {
+        email: mockPerson.email,
+        senha: 'senha123',
+      };
+
+      await service.login(loginDto);
+
+      expect(bcrypt.compare).toHaveBeenCalledWith('senha123', mockPerson.senha);
+    });
+
+    it('busca pessoa por email no repositório', async () => {
+      personRepo.findOne.mockResolvedValue(mockPerson);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const loginDto: LoginDto = {
+        email: mockPerson.email,
+        senha: 'senha123',
+      };
+
+      await service.login(loginDto);
+
+      expect(personRepo.findOne).toHaveBeenCalledWith({
+        where: { email: mockPerson.email },
+      });
+    });
+
+    it('não chama bcrypt.compare se pessoa não for encontrada', async () => {
+      personRepo.findOne.mockResolvedValue(null);
+
+      const loginDto: LoginDto = {
+        email: 'nao@existe.com',
+        senha: 'senha123',
+      };
+
+      await expect(service.login(loginDto)).rejects.toBeInstanceOf(UnauthorizedException);
+      expect(bcrypt.compare).not.toHaveBeenCalled();
+    });
+
+    it('não chama bcrypt.compare se pessoa não tem senha', async () => {
+      const personWithoutPassword: Person = {
+        ...mockPerson,
+        senha: null,
+      };
+      personRepo.findOne.mockResolvedValue(personWithoutPassword);
+
+      const loginDto: LoginDto = {
+        email: mockPerson.email,
+        senha: 'senha123',
+      };
+
+      await expect(service.login(loginDto)).rejects.toBeInstanceOf(UnauthorizedException);
+      expect(bcrypt.compare).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as bcrypt from 'bcrypt';
+import { Repository } from 'typeorm';
+import { Person } from '../people/entities/person.entity';
+import { LoginDto } from './dtos/login.dto';
+import { Role } from '../common/enums/role.enum';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    @InjectRepository(Person)
+    private readonly personRepository: Repository<Person>,
+    private readonly jwtService: JwtService,
+  ) {}
+
+  async login(dto: LoginDto): Promise<{ access_token: string }> {
+    const person = await this.personRepository.findOne({
+      where: { email: dto.email },
+    });
+
+    if (!person) {
+      throw new UnauthorizedException('Email ou senha inválidos');
+    }
+
+    if (!person.senha) {
+      throw new UnauthorizedException('Email ou senha inválidos');
+    }
+
+    const isPasswordValid = await bcrypt.compare(dto.senha, person.senha);
+    if (!isPasswordValid) {
+      throw new UnauthorizedException('Email ou senha inválidos');
+    }
+
+    const payload = {
+      sub: person.cpf,
+      email: person.email,
+      role: Role.CLIENTE, // Será atualizado em D2 quando Employee for implementado
+    };
+
+    const access_token = this.jwtService.sign(payload);
+
+    return { access_token };
+  }
+}

--- a/src/auth/dtos/login.dto.ts
+++ b/src/auth/dtos/login.dto.ts
@@ -1,0 +1,9 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+export const LoginSchema = z.object({
+  email: z.string().email('Email inválido'),
+  senha: z.string().min(1, 'Senha é obrigatória'),
+});
+
+export class LoginDto extends createZodDto(LoginSchema) {}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+export interface JwtPayload {
+  sub: string;
+  email: string;
+  role: string;
+}
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: process.env.JWT_SECRET || 'your-super-secret-jwt-key-change-this-in-production',
+    } as any);
+  }
+
+  async validate(payload: JwtPayload) {
+    return {
+      sub: payload.sub,
+      email: payload.email,
+      role: payload.role,
+    };
+  }
+}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -14,7 +14,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: process.env.JWT_SECRET || 'your-super-secret-jwt-key-change-this-in-production',
+      secretOrKey: process.env.JWT_SECRET,
     } as any);
   }
 

--- a/src/common/decorators/current-user.decorator.ts
+++ b/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,14 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export interface CurrentUserPayload {
+  sub: string;
+  email: string;
+  role: string;
+}
+
+export const CurrentUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): CurrentUserPayload => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/src/common/decorators/index.ts
+++ b/src/common/decorators/index.ts
@@ -1,0 +1,2 @@
+export { CurrentUser, type CurrentUserPayload } from './current-user.decorator';
+export { Roles } from './roles.decorator';

--- a/src/common/decorators/roles.decorator.ts
+++ b/src/common/decorators/roles.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '../enums/role.enum';
+
+export const Roles = (...roles: Role[]) => SetMetadata('roles', roles);

--- a/src/common/decorators/roles.decorator.ts
+++ b/src/common/decorators/roles.decorator.ts
@@ -1,3 +1,29 @@
+/**
+ * @Roles(...roles)
+ *
+ * Decorator que marca quais roles podem acessar um endpoint.
+ * Deve ser usado com RolesGuard para validação.
+ *
+ * Aceita múltiplos perfis (OR logic):
+ * - @Roles('admin') → apenas admin
+ * - @Roles('admin', 'gerente') → admin OU gerente
+ * - @Roles('admin', 'gerente', 'caixa') → qualquer um desses 3
+ *
+ * Roles disponíveis:
+ * - Role.CLIENTE
+ * - Role.CAIXA
+ * - Role.VENDEDOR
+ * - Role.GERENTE
+ * - Role.ADMINISTRADOR
+ *
+ * Uso:
+ * @UseGuards(JwtAuthGuard, RolesGuard)
+ * @Roles(Role.ADMINISTRADOR, Role.GERENTE)
+ * async deleteUser(@Param('id') id: string) { ... }
+ *
+ * Nota: Sem @Roles(), RolesGuard permite qualquer usuario autenticado.
+ */
+
 import { SetMetadata } from '@nestjs/common';
 import { Role } from '../enums/role.enum';
 

--- a/src/common/decorators/roles.decorator.ts
+++ b/src/common/decorators/roles.decorator.ts
@@ -27,4 +27,5 @@
 import { SetMetadata } from '@nestjs/common';
 import { Role } from '../enums/role.enum';
 
-export const Roles = (...roles: Role[]) => SetMetadata('roles', roles);
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/common/enums/index.ts
+++ b/src/common/enums/index.ts
@@ -1,0 +1,1 @@
+export { Role } from './role.enum';

--- a/src/common/enums/role.enum.ts
+++ b/src/common/enums/role.enum.ts
@@ -1,5 +1,6 @@
 export enum Role {
     CLIENTE = 'cliente',
+    CAIXA = 'caixa',
     VENDEDOR = 'vendedor',
     GERENTE = 'gerente',
     ADMINISTRADOR = 'administrador',

--- a/src/common/enums/role.enum.ts
+++ b/src/common/enums/role.enum.ts
@@ -1,0 +1,6 @@
+export enum Role {
+    CLIENTE = 'cliente',
+    VENDEDOR = 'vendedor',
+    GERENTE = 'gerente',
+    ADMINISTRADOR = 'administrador',
+}

--- a/src/common/guards/index.ts
+++ b/src/common/guards/index.ts
@@ -1,0 +1,2 @@
+export { JwtAuthGuard } from './jwt-auth.guard';
+export { RolesGuard } from './roles.guard';

--- a/src/common/guards/jwt-auth.guard.spec.ts
+++ b/src/common/guards/jwt-auth.guard.spec.ts
@@ -1,161 +1,46 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ExecutionContext } from '@nestjs/common';
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
 import { JwtAuthGuard } from './jwt-auth.guard';
-
-/**
- * Mock constants para testes de JwtAuthGuard
- */
-const mockUserPayload = {
-    sub: '12345678901',
-    email: 'test@example.com',
-    role: 'cliente',
-    iat: 1567800000,
-    exp: 1567886400,
-};
-
-const mockValidAuthHeader = 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwMSJ9.signature';
-const mockInvalidAuthHeader = 'Bearer invalid_token_xyz';
-const mockMissingBearerHeader = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwMSJ9.signature';
 
 describe('JwtAuthGuard', () => {
     let guard: JwtAuthGuard;
 
-    beforeEach(async () => {
-        const module: TestingModule = await Test.createTestingModule({
-            providers: [JwtAuthGuard],
-        }).compile();
-
-        guard = module.get<JwtAuthGuard>(JwtAuthGuard);
+    beforeEach(() => {
+        guard = new JwtAuthGuard();
     });
 
-    describe('Comportamento geral', () => {
-        it('deve estar definido', () => {
-            expect(guard).toBeDefined();
-        });
-
-        it('deve ser instância de JwtAuthGuard', () => {
-            expect(guard).toBeInstanceOf(JwtAuthGuard);
-        });
+    it('deve estar definido', () => {
+        expect(guard).toBeDefined();
     });
 
-    describe('Estrutura e herança', () => {
-        it('deve ser classe instanciável do NestJS', () => {
-            expect(typeof JwtAuthGuard).toBe('function');
-        });
+    it('deve delegar para AuthGuard("jwt") e retornar true com token válido', async () => {
+        const mockContext = {} as ExecutionContext;
+        const parentCanActivate = jest
+            .spyOn(AuthGuard('jwt').prototype, 'canActivate')
+            .mockResolvedValue(true);
 
-        it('deve ser um Guard (ter método canActivate quando usado via Passport)', () => {
-            expect(guard).toBeDefined();
-        });
+        const result = await guard.canActivate(mockContext);
+
+        expect(parentCanActivate).toHaveBeenCalledWith(mockContext);
+        expect(result).toBe(true);
+        parentCanActivate.mockRestore();
     });
 
-    describe('Formato do Bearer token (validação básica)', () => {
-        it('deve aceitar formato "Authorization: Bearer <token>"', () => {
-            expect(mockValidAuthHeader).toContain('Bearer');
-            expect(mockValidAuthHeader.startsWith('Bearer ')).toBe(true);
-        });
+    it('deve lançar UnauthorizedException quando o token está ausente', async () => {
+        const mockContext = {} as ExecutionContext;
+        jest
+            .spyOn(AuthGuard('jwt').prototype, 'canActivate')
+            .mockRejectedValue(new UnauthorizedException());
 
-        it('deve rejeitar formato sem "Bearer" prefix (esperado: 401)', () => {
-            expect(mockMissingBearerHeader).not.toContain('Bearer');
-        });
-
-        it('deve reconhecer token inválido (esperado: 401 na integração)', () => {
-            expect(mockInvalidAuthHeader).toContain('Bearer');
-            expect(mockInvalidAuthHeader).not.toMatch(/eyJ.*\.eyJ.*\.[\w-]+$/);
-        });
+        await expect(guard.canActivate(mockContext)).rejects.toThrow(UnauthorizedException);
     });
 
-    describe('Injeção de usuário no request', () => {
-        it('deve permitir injetar payload do token em request.user', () => {
-            expect(mockUserPayload).toHaveProperty('sub');
-            expect(mockUserPayload).toHaveProperty('email');
-            expect(mockUserPayload).toHaveProperty('role');
-            expect(mockUserPayload.sub).toBe('12345678901');
-        });
+    it('deve lançar UnauthorizedException quando o token é inválido ou expirado', async () => {
+        const mockContext = {} as ExecutionContext;
+        jest
+            .spyOn(AuthGuard('jwt').prototype, 'canActivate')
+            .mockRejectedValue(new UnauthorizedException('Token inválido'));
 
-        it('deve validar estrutura do payload com sub, email, role', () => {
-            const requiredFields = ['sub', 'email', 'role', 'iat', 'exp'];
-            requiredFields.forEach((field) => {
-                expect(mockUserPayload).toHaveProperty(field);
-            });
-        });
-
-        it('payload deve conter claims necessários para @CurrentUser()', () => {
-            const { sub, email, role } = mockUserPayload;
-            expect(typeof sub).toBe('string');
-            expect(typeof email).toBe('string');
-            expect(typeof role).toBe('string');
-        });
-    });
-
-    describe('Casos extremos e validações', () => {
-        it('deve rejeitar request sem Authorization header (esperado: 401)', () => {
-            const request = { headers: {} };
-            expect(request.headers).not.toHaveProperty('authorization');
-        });
-
-        it('deve rejeitar Authorization header vazio', () => {
-            const request = { headers: { authorization: '' } };
-            expect(request.headers.authorization).toBe('');
-            expect(!request.headers.authorization).toBe(true);
-        });
-
-        it('deve rejeitar Authorization header null', () => {
-            const request = { headers: { authorization: null } };
-            expect(request.headers.authorization).toBeNull();
-        });
-
-        it('deve rejeitar Bearer token com espaços extras', () => {
-            const malformedHeader = 'Bearer  token_com_espaço';
-            const parts = malformedHeader.split(' ');
-            expect(parts.length).toBeGreaterThan(2);
-        });
-
-        it('deve rejeitar Authorization header undefined', () => {
-            const request = { headers: { authorization: undefined } };
-            expect(request.headers.authorization).toBeUndefined();
-        });
-    });
-
-    describe('Integração com RolesGuard', () => {
-        it('deve funcionar precedendo RolesGuard na ordem de guards', () => {
-            expect(guard).toBeDefined();
-        });
-
-        it('deve permitir que RolesGuard acesse user.role após validação', () => {
-            expect(mockUserPayload.role).toBe('cliente');
-        });
-    });
-
-    describe('Fluxo de autenticação esperado', () => {
-        it('fluxo: request com token válido → injetar user → permitir acesso', () => {
-            const request = { headers: { authorization: mockValidAuthHeader } };
-            expect(request.headers.authorization).toBeDefined();
-            expect(mockValidAuthHeader).toContain('Bearer');
-            expect(mockUserPayload).toHaveProperty('sub');
-            expect(mockUserPayload).toHaveProperty('email');
-        });
-
-        it('fluxo: request sem token → rejeitar com 401', () => {
-            const request = { headers: {} };
-            expect((request.headers as any).authorization).toBeUndefined();
-        });
-
-        it('fluxo: request com token inválido → rejeitar com 401', () => {
-            const request = { headers: { authorization: mockInvalidAuthHeader } };
-            expect(request.headers.authorization).toBeDefined();
-        });
-    });
-
-    describe('Compatibilidade com @CurrentUser() decorator', () => {
-        it('deve manter payload injetado acessível para decorators', () => {
-            const request = { user: mockUserPayload };
-            expect(request.user.sub).toBe('12345678901');
-            expect(request.user.email).toBe('test@example.com');
-        });
-
-        it('deve permitir extrair CPF do sub (payload.sub)', () => {
-            expect(mockUserPayload.sub).toBe('12345678901');
-            expect(mockUserPayload.sub.length).toBe(11);
-        });
+        await expect(guard.canActivate(mockContext)).rejects.toThrow(UnauthorizedException);
     });
 });

--- a/src/common/guards/jwt-auth.guard.spec.ts
+++ b/src/common/guards/jwt-auth.guard.spec.ts
@@ -1,0 +1,161 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext } from '@nestjs/common';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+/**
+ * Mock constants para testes de JwtAuthGuard
+ */
+const mockUserPayload = {
+    sub: '12345678901',
+    email: 'test@example.com',
+    role: 'cliente',
+    iat: 1567800000,
+    exp: 1567886400,
+};
+
+const mockValidAuthHeader = 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwMSJ9.signature';
+const mockInvalidAuthHeader = 'Bearer invalid_token_xyz';
+const mockMissingBearerHeader = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwMSJ9.signature';
+
+describe('JwtAuthGuard', () => {
+    let guard: JwtAuthGuard;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [JwtAuthGuard],
+        }).compile();
+
+        guard = module.get<JwtAuthGuard>(JwtAuthGuard);
+    });
+
+    describe('Comportamento geral', () => {
+        it('deve estar definido', () => {
+            expect(guard).toBeDefined();
+        });
+
+        it('deve ser instância de JwtAuthGuard', () => {
+            expect(guard).toBeInstanceOf(JwtAuthGuard);
+        });
+    });
+
+    describe('Estrutura e herança', () => {
+        it('deve ser classe instanciável do NestJS', () => {
+            expect(typeof JwtAuthGuard).toBe('function');
+        });
+
+        it('deve ser um Guard (ter método canActivate quando usado via Passport)', () => {
+            expect(guard).toBeDefined();
+        });
+    });
+
+    describe('Formato do Bearer token (validação básica)', () => {
+        it('deve aceitar formato "Authorization: Bearer <token>"', () => {
+            expect(mockValidAuthHeader).toContain('Bearer');
+            expect(mockValidAuthHeader.startsWith('Bearer ')).toBe(true);
+        });
+
+        it('deve rejeitar formato sem "Bearer" prefix (esperado: 401)', () => {
+            expect(mockMissingBearerHeader).not.toContain('Bearer');
+        });
+
+        it('deve reconhecer token inválido (esperado: 401 na integração)', () => {
+            expect(mockInvalidAuthHeader).toContain('Bearer');
+            expect(mockInvalidAuthHeader).not.toMatch(/eyJ.*\.eyJ.*\.[\w-]+$/);
+        });
+    });
+
+    describe('Injeção de usuário no request', () => {
+        it('deve permitir injetar payload do token em request.user', () => {
+            expect(mockUserPayload).toHaveProperty('sub');
+            expect(mockUserPayload).toHaveProperty('email');
+            expect(mockUserPayload).toHaveProperty('role');
+            expect(mockUserPayload.sub).toBe('12345678901');
+        });
+
+        it('deve validar estrutura do payload com sub, email, role', () => {
+            const requiredFields = ['sub', 'email', 'role', 'iat', 'exp'];
+            requiredFields.forEach((field) => {
+                expect(mockUserPayload).toHaveProperty(field);
+            });
+        });
+
+        it('payload deve conter claims necessários para @CurrentUser()', () => {
+            const { sub, email, role } = mockUserPayload;
+            expect(typeof sub).toBe('string');
+            expect(typeof email).toBe('string');
+            expect(typeof role).toBe('string');
+        });
+    });
+
+    describe('Casos extremos e validações', () => {
+        it('deve rejeitar request sem Authorization header (esperado: 401)', () => {
+            const request = { headers: {} };
+            expect(request.headers).not.toHaveProperty('authorization');
+        });
+
+        it('deve rejeitar Authorization header vazio', () => {
+            const request = { headers: { authorization: '' } };
+            expect(request.headers.authorization).toBe('');
+            expect(!request.headers.authorization).toBe(true);
+        });
+
+        it('deve rejeitar Authorization header null', () => {
+            const request = { headers: { authorization: null } };
+            expect(request.headers.authorization).toBeNull();
+        });
+
+        it('deve rejeitar Bearer token com espaços extras', () => {
+            const malformedHeader = 'Bearer  token_com_espaço';
+            const parts = malformedHeader.split(' ');
+            expect(parts.length).toBeGreaterThan(2);
+        });
+
+        it('deve rejeitar Authorization header undefined', () => {
+            const request = { headers: { authorization: undefined } };
+            expect(request.headers.authorization).toBeUndefined();
+        });
+    });
+
+    describe('Integração com RolesGuard', () => {
+        it('deve funcionar precedendo RolesGuard na ordem de guards', () => {
+            expect(guard).toBeDefined();
+        });
+
+        it('deve permitir que RolesGuard acesse user.role após validação', () => {
+            expect(mockUserPayload.role).toBe('cliente');
+        });
+    });
+
+    describe('Fluxo de autenticação esperado', () => {
+        it('fluxo: request com token válido → injetar user → permitir acesso', () => {
+            const request = { headers: { authorization: mockValidAuthHeader } };
+            expect(request.headers.authorization).toBeDefined();
+            expect(mockValidAuthHeader).toContain('Bearer');
+            expect(mockUserPayload).toHaveProperty('sub');
+            expect(mockUserPayload).toHaveProperty('email');
+        });
+
+        it('fluxo: request sem token → rejeitar com 401', () => {
+            const request = { headers: {} };
+            expect((request.headers as any).authorization).toBeUndefined();
+        });
+
+        it('fluxo: request com token inválido → rejeitar com 401', () => {
+            const request = { headers: { authorization: mockInvalidAuthHeader } };
+            expect(request.headers.authorization).toBeDefined();
+        });
+    });
+
+    describe('Compatibilidade com @CurrentUser() decorator', () => {
+        it('deve manter payload injetado acessível para decorators', () => {
+            const request = { user: mockUserPayload };
+            expect(request.user.sub).toBe('12345678901');
+            expect(request.user.email).toBe('test@example.com');
+        });
+
+        it('deve permitir extrair CPF do sub (payload.sub)', () => {
+            expect(mockUserPayload.sub).toBe('12345678901');
+            expect(mockUserPayload.sub.length).toBe(11);
+        });
+    });
+});

--- a/src/common/guards/jwt-auth.guard.ts
+++ b/src/common/guards/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/src/common/guards/jwt-auth.guard.ts
+++ b/src/common/guards/jwt-auth.guard.ts
@@ -1,5 +1,35 @@
+/**
+ * JwtAuthGuard
+ *
+ * Guard de autenticação via JWT (JSON Web Token).
+ * Valida se a requisição contém um token JWT válido no header Authorization.
+ *
+ * Comportamento:
+ * -  Token válido: permite acesso, injeta usuário no request
+ * -  Sem token: retorna 401 Unauthorized
+ * -  Token inválido/expirado: retorna 401 Unauthorized
+ *
+ * Uso em endpoints:
+ * @UseGuards(JwtAuthGuard)
+ * async findOne(@Param('id') id: string) {
+ *   // Apenas usuários autenticados chegam aqui
+ * }
+ *
+ * Com outros guards:
+ * @UseGuards(JwtAuthGuard, RolesGuard)
+ * @Roles('admin', 'gerente')
+ * async remove(@Param('id') id: string) {
+ *   // Apenas admin e gerente autenticados chegam aqui
+ * }
+ *
+ * Extração do token:
+ * - Header: Authorization: Bearer <token>
+ * - Validação: Usa JwtStrategy do módulo auth
+ * - Secret: JWT_SECRET do .env
+ */
+
 import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') { }

--- a/src/common/guards/roles.guard.spec.ts
+++ b/src/common/guards/roles.guard.spec.ts
@@ -1,8 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { RolesGuard } from './roles.guard';
 import { Role } from '../enums/role.enum';
+import { ROLES_KEY } from '../decorators/roles.decorator';
 
 describe('RolesGuard', () => {
     let guard: RolesGuard;
@@ -377,7 +378,7 @@ describe('RolesGuard', () => {
 
             guard.canActivate(mockExecutionContext);
 
-            expect(reflector.get).toHaveBeenCalledWith('roles', mockHandler);
+            expect(reflector.get).toHaveBeenCalledWith(ROLES_KEY, mockHandler);
         });
 
         it('deve passar handler correto para Reflector.get()', () => {
@@ -395,7 +396,7 @@ describe('RolesGuard', () => {
 
             guard.canActivate(mockExecutionContext);
 
-            expect(reflector.get).toHaveBeenCalledWith('roles', mockHandler);
+            expect(reflector.get).toHaveBeenCalledWith(ROLES_KEY, mockHandler);
         });
     });
 

--- a/src/common/guards/roles.guard.spec.ts
+++ b/src/common/guards/roles.guard.spec.ts
@@ -1,0 +1,501 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from './roles.guard';
+import { Role } from '../enums/role.enum';
+
+describe('RolesGuard', () => {
+    let guard: RolesGuard;
+    let reflector: jest.Mocked<Reflector>;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                RolesGuard,
+                {
+                    provide: Reflector,
+                    useValue: {
+                        get: jest.fn(),
+                    },
+                },
+            ],
+        }).compile();
+
+        guard = module.get<RolesGuard>(RolesGuard);
+        reflector = module.get(Reflector) as jest.Mocked<Reflector>;
+    });
+
+    describe('Comportamento geral', () => {
+        it('deve estar definido', () => {
+            expect(guard).toBeDefined();
+        });
+
+        it('deve implementar CanActivate', () => {
+            expect(guard.canActivate).toBeDefined();
+            expect(typeof guard.canActivate).toBe('function');
+        });
+    });
+
+    describe('Sem @Roles() decorator', () => {
+        it('deve permitir qualquer usuário autenticado quando sem @Roles()', () => {
+            reflector.get.mockReturnValue(undefined);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.CLIENTE },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+
+            expect(result).toBe(true);
+        });
+
+        it('deve permitir qualquer role quando @Roles() não está definido', () => {
+            reflector.get.mockReturnValue(undefined);
+
+            const testCases = [
+                Role.CLIENTE,
+                Role.CAIXA,
+                Role.VENDEDOR,
+                Role.GERENTE,
+                Role.ADMINISTRADOR,
+            ];
+
+            testCases.forEach((role) => {
+                const mockExecutionContext = {
+                    switchToHttp: () => ({
+                        getRequest: () => ({
+                            user: { role },
+                        }),
+                    }),
+                    getHandler: () => ({}),
+                } as unknown as ExecutionContext;
+
+                const result = guard.canActivate(mockExecutionContext);
+                expect(result).toBe(true);
+            });
+        });
+    });
+
+    describe('Critério de aceite: 403 com role inadequada', () => {
+        it('deve rejeitar com 403 quando role inadequada é usada', () => {
+            /**
+             * Cenário:
+             * @UseGuards(JwtAuthGuard, RolesGuard)
+             * @Roles(Role.ADMINISTRADOR)
+             * async deleteUser() { ... }
+             *
+             * Token do usuário: role = 'cliente'
+             *
+             * Esperado: 403 Forbidden
+             */
+            reflector.get.mockReturnValue([Role.ADMINISTRADOR]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.CLIENTE },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+
+            // NestJS interpreta false como 403 Forbidden automaticamente
+            expect(result).toBe(false);
+        });
+
+        it('deve retornar false para role: cliente quando requer administrador', () => {
+            reflector.get.mockReturnValue([Role.ADMINISTRADOR]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.CLIENTE },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+            expect(result).toBe(false);
+        });
+
+        it('deve retornar false para role: vendedor quando requer gerente', () => {
+            reflector.get.mockReturnValue([Role.GERENTE]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.VENDEDOR },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+            expect(result).toBe(false);
+        });
+
+        it('deve retornar false para role: caixa quando requer administrador', () => {
+            reflector.get.mockReturnValue([Role.ADMINISTRADOR]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.CAIXA },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('Critério de aceite: Múltiplos perfis aceitáveis', () => {
+        it('deve aceitar role quando está em múltiplos perfis permitidos', () => {
+            /**
+             * Cenário:
+             * @Roles(Role.ADMINISTRADOR, Role.GERENTE)
+             *
+             * Token do usuário: role = 'gerente'
+             *
+             * Esperado: 200 OK (true)
+             */
+            reflector.get.mockReturnValue([Role.ADMINISTRADOR, Role.GERENTE]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.GERENTE },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+
+            expect(result).toBe(true);
+        });
+
+        it('deve aceitar admin quando @Roles(admin, gerente)', () => {
+            reflector.get.mockReturnValue([Role.ADMINISTRADOR, Role.GERENTE]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.ADMINISTRADOR },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+            expect(result).toBe(true);
+        });
+
+        it('deve aceitar qualquer role em @Roles(admin, gerente, vendedor, caixa, cliente)', () => {
+            const allRoles = [
+                Role.ADMINISTRADOR,
+                Role.GERENTE,
+                Role.VENDEDOR,
+                Role.CAIXA,
+                Role.CLIENTE,
+            ];
+
+            reflector.get.mockReturnValue(allRoles);
+
+            allRoles.forEach((role) => {
+                const mockExecutionContext = {
+                    switchToHttp: () => ({
+                        getRequest: () => ({
+                            user: { role },
+                        }),
+                    }),
+                    getHandler: () => ({}),
+                } as unknown as ExecutionContext;
+
+                const result = guard.canActivate(mockExecutionContext);
+                expect(result).toBe(true);
+            });
+        });
+
+        it('deve rejeitar role fora da lista de múltiplos perfis', () => {
+            reflector.get.mockReturnValue([Role.ADMINISTRADOR, Role.GERENTE]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.CLIENTE },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+            expect(result).toBe(false);
+        });
+
+        it('deve aceitar vendedor quando @Roles(vendedor, caixa)', () => {
+            reflector.get.mockReturnValue([Role.VENDEDOR, Role.CAIXA]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.VENDEDOR },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+            expect(result).toBe(true);
+        });
+    });
+
+    describe('Casos extremos', () => {
+        it('deve retornar false quando user é undefined', () => {
+            reflector.get.mockReturnValue([Role.ADMINISTRADOR]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: undefined,
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+            expect(result).toBe(false);
+        });
+
+        it('deve retornar false quando user.role é undefined', () => {
+            reflector.get.mockReturnValue([Role.ADMINISTRADOR]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: undefined },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+            expect(result).toBe(false);
+        });
+
+        it('deve retornar false quando user é null', () => {
+            reflector.get.mockReturnValue([Role.ADMINISTRADOR]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: null,
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+            expect(result).toBe(false);
+        });
+
+        it('deve retornar false quando requiredRoles é array vazio (nunca deve acontecer)', () => {
+            reflector.get.mockReturnValue([]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.CLIENTE },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('Case sensitivity', () => {
+        it('deve fazer match exato de role (case-sensitive)', () => {
+            reflector.get.mockReturnValue([Role.ADMINISTRADOR]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: 'ADMINISTRADOR' }, // uppercase
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+            // Enum value é 'administrador' (lowercase), não 'ADMINISTRADOR'
+            expect(result).toBe(false);
+        });
+
+        it('deve aceitar role com case correto', () => {
+            reflector.get.mockReturnValue([Role.ADMINISTRADOR]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: 'administrador' }, // lowercase correto
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+            expect(result).toBe(true);
+        });
+    });
+
+    describe('Integração com @Roles() decorator', () => {
+        it('deve usar Reflector.get() para obter metadata de @Roles()', () => {
+            reflector.get.mockReturnValue([Role.GERENTE]);
+
+            const mockHandler = jest.fn();
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.GERENTE },
+                    }),
+                }),
+                getHandler: () => mockHandler,
+            } as unknown as ExecutionContext;
+
+            guard.canActivate(mockExecutionContext);
+
+            expect(reflector.get).toHaveBeenCalledWith('roles', mockHandler);
+        });
+
+        it('deve passar handler correto para Reflector.get()', () => {
+            const mockHandler = jest.fn();
+            reflector.get.mockReturnValue([Role.ADMINISTRADOR]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.ADMINISTRADOR },
+                    }),
+                }),
+                getHandler: () => mockHandler,
+            } as unknown as ExecutionContext;
+
+            guard.canActivate(mockExecutionContext);
+
+            expect(reflector.get).toHaveBeenCalledWith('roles', mockHandler);
+        });
+    });
+
+    describe('Testes E2E (cenários realistas)', () => {
+        it('Cenário 1: Admin deletando usuário com @Roles(ADMINISTRADOR)', () => {
+            /**
+             * @UseGuards(JwtAuthGuard, RolesGuard)
+             * @Roles(Role.ADMINISTRADOR)
+             * @Delete('users/:id')
+             * async deleteUser(@Param('id') id: string) { ... }
+             *
+             * Usuário com token admin tentando deletar → 200 OK
+             */
+            reflector.get.mockReturnValue([Role.ADMINISTRADOR]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.ADMINISTRADOR },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+            expect(result).toBe(true);
+        });
+
+        it('Cenário 2: Cliente tentando deletar usuário com @Roles(ADMINISTRADOR)', () => {
+            /**
+             * @UseGuards(JwtAuthGuard, RolesGuard)
+             * @Roles(Role.ADMINISTRADOR)
+             * @Delete('users/:id')
+             * async deleteUser(@Param('id') id: string) { ... }
+             *
+             * Usuário com token cliente tentando deletar → 403 Forbidden
+             */
+            reflector.get.mockReturnValue([Role.ADMINISTRADOR]);
+
+            const mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.CLIENTE },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            const result = guard.canActivate(mockExecutionContext);
+            expect(result).toBe(false);
+        });
+
+        it('Cenário 3: Gerente vendo dashboard com @Roles(GERENTE, ADMINISTRADOR)', () => {
+            /**
+             * @UseGuards(JwtAuthGuard, RolesGuard)
+             * @Roles(Role.GERENTE, Role.ADMINISTRADOR)
+             * @Get('dashboard')
+             * async viewDashboard() { ... }
+             *
+             * Gerente → 200 OK
+             * Admin → 200 OK
+             * Vendedor → 403 Forbidden
+             */
+            reflector.get.mockReturnValue([Role.GERENTE, Role.ADMINISTRADOR]);
+
+            // Gerente OK
+            let mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.GERENTE },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            expect(guard.canActivate(mockExecutionContext)).toBe(true);
+
+            // Admin OK
+            mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.ADMINISTRADOR },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            expect(guard.canActivate(mockExecutionContext)).toBe(true);
+
+            // Vendedor REJEITADO
+            mockExecutionContext = {
+                switchToHttp: () => ({
+                    getRequest: () => ({
+                        user: { role: Role.VENDEDOR },
+                    }),
+                }),
+                getHandler: () => ({}),
+            } as unknown as ExecutionContext;
+
+            expect(guard.canActivate(mockExecutionContext)).toBe(false);
+        });
+    });
+});

--- a/src/common/guards/roles.guard.ts
+++ b/src/common/guards/roles.guard.ts
@@ -45,13 +45,14 @@
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Role } from '../enums/role.enum';
+import { ROLES_KEY } from '../decorators/roles.decorator';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
     constructor(private reflector: Reflector) { }
 
     canActivate(context: ExecutionContext): boolean {
-        const requiredRoles = this.reflector.get<Role[]>('roles', context.getHandler());
+        const requiredRoles = this.reflector.get<Role[]>(ROLES_KEY, context.getHandler());
         if (!requiredRoles) {
             return true;
         }

--- a/src/common/guards/roles.guard.ts
+++ b/src/common/guards/roles.guard.ts
@@ -1,0 +1,18 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Role } from '../enums/role.enum';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.get<Role[]>('roles', context.getHandler());
+    if (!requiredRoles) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+    return requiredRoles.some((role) => user?.role === role);
+  }
+}

--- a/src/common/guards/roles.guard.ts
+++ b/src/common/guards/roles.guard.ts
@@ -1,18 +1,62 @@
+/**
+ * RolesGuard
+ *
+ * Guard de autorização baseado em roles (perfis de usuário).
+ * Verifica se o usuário autenticado possui uma das roles necessárias.
+ *
+ * IMPORTANTE: Use com JwtAuthGuard para garantir que o usuário está autenticado.
+ *
+ * Comportamento:
+ * - Sem @Roles(): permite qualquer usuário autenticado
+ * - Com @Roles('admin'): apenas admin pode acessar
+ * - Com @Roles('admin', 'gerente'): admin OU gerente podem acessar
+ * - Role inadequada: retorna 403 Forbidden
+ *
+ * Roles disponíveis (conforme Role enum):
+ * - 'cliente': usuário comum
+ * - 'caixa': pode registrar vendas
+ * - 'vendedor': pode ver comissões
+ * - 'gerente': acesso a dashboards e estoque
+ * - 'administrador': acesso total
+ *
+ * Uso em endpoints:
+ *
+ * 1️ Apenas autenticado (qualquer role):
+ * @UseGuards(JwtAuthGuard)
+ * async findAll() { ... }
+ *
+ * 2️ Apenas admin:
+ * @UseGuards(JwtAuthGuard, RolesGuard)
+ * @Roles('administrador')
+ * async deleteAll() { ... }
+ *
+ * 3️ Admin OU Gerente:
+ * @UseGuards(JwtAuthGuard, RolesGuard)
+ * @Roles('administrador', 'gerente')
+ * async viewDashboard() { ... }
+ *
+ * Fluxo de validação:
+ * 1. JwtAuthGuard valida token e injeta user no request
+ * 2. Reflector extrai roles da metadata @Roles()
+ * 3. Compara user.role com roles requiridas
+ * 4. Retorna true (permite) ou false (bloqueia com 403)
+ */
+
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Role } from '../enums/role.enum';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
-  constructor(private reflector: Reflector) {}
+    constructor(private reflector: Reflector) { }
 
-  canActivate(context: ExecutionContext): boolean {
-    const requiredRoles = this.reflector.get<Role[]>('roles', context.getHandler());
-    if (!requiredRoles) {
-      return true;
+    canActivate(context: ExecutionContext): boolean {
+        const requiredRoles = this.reflector.get<Role[]>('roles', context.getHandler());
+        if (!requiredRoles) {
+            return true;
+        }
+
+        const { user } = context.switchToHttp().getRequest();
+        return requiredRoles.some((role) => user?.role === role);
     }
-
-    const { user } = context.switchToHttp().getRequest();
-    return requiredRoles.some((role) => user?.role === role);
-  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,17 @@ async function bootstrap() {
     .setTitle('API DK Fashion')
     .setDescription('Documentação da API com Swagger')
     .setVersion('1.0.0')
-    .addBearerAuth()
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        name: 'JWT',
+        description: 'Insira **APENAS** o token JWT gerado no login. Não digite a palavra "Bearer ".',
+        in: 'header',
+      },
+      'bearer', // Nome do scheme de segurança, que o @ApiBearerAuth() usa por padrão
+    )
     .build();
 
   const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig);

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { Logger } from '@nestjs/common';
 import { AppModule } from './app.module';
 
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { ZodValidationPipe } from 'nestjs-zod';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
@@ -10,6 +11,9 @@ async function bootstrap() {
   logger.log('Inicializando aplicação NestJS...');
 
   const app = await NestFactory.create(AppModule);
+
+  // Adicionar ZodValidationPipe globalmente
+  app.useGlobalPipes(new ZodValidationPipe());
 
   // o prefixo funciona apenas para as controllers
   // como o swagger está por fora, basta acessar apenas pelo prefixo /docs

--- a/src/people/people.controller.ts
+++ b/src/people/people.controller.ts
@@ -9,8 +9,10 @@ import {
   Patch,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import {
+  ApiBearerAuth,
   ApiOperation,
   ApiParam,
   ApiQuery,
@@ -22,6 +24,7 @@ import { z } from 'zod';
 import { CreatePersonDto } from './dtos/create-person.dto';
 import { UpdatePersonDto } from './dtos/update-person.dto';
 import { PeopleService } from './people.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 
 /**
  * Schema de paginação local. Será movido para `src/common/` em D2, quando
@@ -56,6 +59,8 @@ export class PeopleController {
   }
 
   @Get()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Lista pessoas com paginação' })
   @ApiQuery({ name: 'page', required: false, example: 1 })
   @ApiQuery({ name: 'limit', required: false, example: 20 })
@@ -65,6 +70,8 @@ export class PeopleController {
   }
 
   @Get(':cpf')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Busca uma pessoa por CPF' })
   @ApiParam({ name: 'cpf', description: 'CPF (11 dígitos sem máscara)' })
   @ApiResponse({ status: 200, description: 'Pessoa encontrada' })
@@ -74,6 +81,8 @@ export class PeopleController {
   }
 
   @Patch(':cpf')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Atualiza dados de uma pessoa' })
   @ApiParam({ name: 'cpf', description: 'CPF (11 dígitos sem máscara)' })
   @ApiResponse({ status: 200, description: 'Pessoa atualizada' })
@@ -84,6 +93,8 @@ export class PeopleController {
   }
 
   @Delete(':cpf')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Remove uma pessoa' })
   @ApiParam({ name: 'cpf', description: 'CPF (11 dígitos sem máscara)' })


### PR DESCRIPTION
This pull request introduces a complete authentication and authorization system to the project, including JWT-based login, role-based access control, and supporting utilities. It adds an `AuthModule` with login endpoint, JWT strategy, guards, role decorators, and comprehensive tests. Additionally, it improves developer experience with Makefile utilities for secret management and clarifies the `Role` enum and its usage.

**Authentication & Authorization Implementation:**

- **Auth Module and Login Endpoint:**  
  Adds a new `AuthModule` with a `POST /auth/login` endpoint that authenticates users using email and password, returning a JWT token on success. The login flow uses bcrypt for password validation and issues JWTs with user information. (`src/auth/auth.module.ts` [[1]](diffhunk://#diff-d5cfad084289d1504e5322be173d5f5af9b85f4f90316b440e269218e18bc457R1-R23) `src/auth/auth.controller.ts` [[2]](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9R1-R31) `src/auth/auth.service.ts` [[3]](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cR1-R46) `src/auth/dtos/login.dto.ts` [[4]](diffhunk://#diff-315721924e7c161240c12297557d04c7d33dd22aeab2c1a937c39bbb1c1ed776R1-R9)

- **JWT Strategy and Guards:**  
  Implements a `JwtStrategy` for validating JWT tokens, a `JwtAuthGuard` to protect endpoints, and a `RolesGuard` for role-based access control. Includes decorators for extracting the current user and specifying allowed roles on endpoints. (`src/auth/strategies/jwt.strategy.ts` [[1]](diffhunk://#diff-7b8cc64e52efca5638a1741d6988b2cfa29382b8ec7feab4be316c946555f8f8R1-R28) `src/common/guards/jwt-auth.guard.ts` [[2]](diffhunk://#diff-216bad2fb18530f79cfabba3b94e27416ba087b9e057c3deb277d110ecc801acR1-R35) `src/common/guards/roles.guard.ts` [[3]](diffhunk://#diff-a634dfd4eadafa26d03a696d8c26cb5652bb1c364ab9d989100f1a114d906837R1-R63) `src/common/decorators/current-user.decorator.ts` [[4]](diffhunk://#diff-85d022727e346c3a9247f8dbfa5d75145999d4b80676d4d920a2fceb26f9742dR1-R14) `src/common/decorators/roles.decorator.ts` [[5]](diffhunk://#diff-cf0817041d3f94e9ef897251e88840eabd87adffea77f76b66f64ecde6d38345R1-R31)

- **Role Enum and Usage:**  
  Introduces a unified `Role` enum, updates documentation to clarify the meaning of each role, and ensures consistent use across authentication and authorization logic. (`src/common/enums/role.enum.ts` [[1]](diffhunk://#diff-8d27e9ee0205cbf88543f6097cd963d5441ff4ad64a97868a4416fbef43cabd3R1-R7) `CLAUDE.md` [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R100-R109)

**Testing and Utilities:**

- **Comprehensive Tests:**  
  Adds unit tests for the authentication service and JWT guard, covering success and failure scenarios for login and token validation. (`src/auth/auth.service.spec.ts` [[1]](diffhunk://#diff-e2c557e1b9c23de431746c5b1a397b0179fa0b51954f24ac09c7fbf93e910e35R1-R190) `src/common/guards/jwt-auth.guard.spec.ts` [[2]](diffhunk://#diff-7426ecad9d79f1423006cf507b78a46a13164242d1fccf710b3f81fdbc7a8618R1-R46)

- **Developer Experience Improvements:**  
  Enhances the `Makefile` with a `gen-secrets` command to generate and insert a random `JWT_SECRET` into environment files, easing setup for developers. Updates help and setup instructions accordingly. (`Makefile` [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L9-R9) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R48) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R57-R70)

**Exports and Integration:**

- **Exports and App Integration:**  
  Exports new enums, guards, and decorators for use throughout the codebase. Integrates `AuthModule` into the main application module. (`src/common/enums/index.ts` [[1]](diffhunk://#diff-497c1dd5b03d63458d6b7609d0e4aa31c4b478609c3743dc206b260d845b34f0R1) `src/common/guards/index.ts` [[2]](diffhunk://#diff-92ac80ff642c1cb6c8182944cc8275e4159740cf7c01e493e2aadb8e039a9f17R1-R2) `src/common/decorators/index.ts` [[3]](diffhunk://#diff-1206f4238c1426b53a8d3b3ca76929a34035f27f728978766431d9ee346bdba0R1-R2) `src/app.module.ts` [[4]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R16) [[5]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R48)