### PR TITLE
chore: update Swagger API operation summaries to improve access level…

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -11,7 +11,7 @@ export class AuthController {
 
   @Post('login')
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Autentica um usuário e retorna um JWT' })
+  @ApiOperation({ summary: 'Autentica um usuário e retorna um JWT (Público)' })
   @ApiResponse({
     status: 200,
     description: 'Login bem-sucedido',

--- a/src/categories/categories.controller.ts
+++ b/src/categories/categories.controller.ts
@@ -40,7 +40,7 @@ export class CategoriesController {
   @Roles(Role.ADMINISTRADOR)
   @ApiBearerAuth()
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Cria uma categoria' })
+  @ApiOperation({ summary: 'Cria uma categoria (Administrador)' })
   @ApiResponse({ status: 201, description: 'Categoria criada com sucesso' })
   @ApiResponse({ status: 400, description: 'Payload inválido' })
   create(@Body() dto: CreateCategoryDto) {
@@ -48,7 +48,7 @@ export class CategoriesController {
   }
 
   @Get()
-  @ApiOperation({ summary: 'Lista categorias' })
+  @ApiOperation({ summary: 'Lista categorias (Público)' })
   @ApiQuery({ name: 'page', required: false, example: 1 })
   @ApiQuery({ name: 'limit', required: false, example: 20 })
   @ApiResponse({ status: 200, description: 'Lista paginada de categorias' })
@@ -57,7 +57,7 @@ export class CategoriesController {
   }
 
   @Get(':id')
-  @ApiOperation({ summary: 'Busca uma categoria por id' })
+  @ApiOperation({ summary: 'Busca uma categoria por id (Público)' })
   @ApiParam({ name: 'id', type: Number })
   @ApiResponse({ status: 200, description: 'Categoria encontrada' })
   @ApiResponse({ status: 404, description: 'Categoria não encontrada' })
@@ -69,7 +69,7 @@ export class CategoriesController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMINISTRADOR)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Atualiza uma categoria' })
+  @ApiOperation({ summary: 'Atualiza uma categoria (Administrador)' })
   @ApiParam({ name: 'id', type: Number })
   @ApiResponse({ status: 200, description: 'Categoria atualizada' })
   @ApiResponse({ status: 400, description: 'Payload inválido' })
@@ -83,7 +83,7 @@ export class CategoriesController {
   @Roles(Role.ADMINISTRADOR)
   @ApiBearerAuth()
   @HttpCode(HttpStatus.NO_CONTENT)
-  @ApiOperation({ summary: 'Remove uma categoria' })
+  @ApiOperation({ summary: 'Remove uma categoria (Administrador)' })
   @ApiParam({ name: 'id', type: Number })
   @ApiResponse({ status: 204, description: 'Categoria removida' })
   @ApiResponse({ status: 404, description: 'Categoria não encontrada' })

--- a/src/coupons/coupons.controller.ts
+++ b/src/coupons/coupons.controller.ts
@@ -80,7 +80,9 @@ export class CouponsController {
   }
 
   @Get('validate/:numero')
-  @ApiOperation({ summary: 'Valida publicamente um cupom de desconto para aplicação em compra' })
+  @ApiOperation({
+    summary: 'Valida publicamente um cupom de desconto para aplicação em compra (Público)',
+  })
   @ApiParam({ name: 'numero', description: 'Código do cupom' })
   @ApiQuery({
     name: 'productIds',

--- a/src/employees/employees.controller.ts
+++ b/src/employees/employees.controller.ts
@@ -27,7 +27,7 @@ export class EmployeesController {
   constructor(private readonly employeesService: EmployeesService) {}
 
   @Post()
-  @ApiOperation({ summary: 'Cadastra um funcionário em uma única chamada' })
+  @ApiOperation({ summary: 'Cadastra um funcionário em uma única chamada (Administrador)' })
   @ApiResponse({ status: 201, description: 'Funcionário criado com sucesso' })
   @ApiResponse({ status: 400, description: 'Payload inválido' })
   @ApiResponse({ status: 403, description: 'Acesso negado' })
@@ -37,7 +37,7 @@ export class EmployeesController {
   }
 
   @Get()
-  @ApiOperation({ summary: 'Lista funcionários com paginação' })
+  @ApiOperation({ summary: 'Lista funcionários com paginação (Administrador)' })
   @ApiQuery({ name: 'page', required: false, example: 1 })
   @ApiQuery({ name: 'limit', required: false, example: 20 })
   @ApiResponse({ status: 200, description: 'Lista paginada de funcionários' })
@@ -47,7 +47,10 @@ export class EmployeesController {
 
   @Get('ranking')
   @Roles(Role.CAIXA, Role.VENDEDOR, Role.GERENTE, Role.ADMINISTRADOR)
-  @ApiOperation({ summary: 'Visualiza o ranking mensal dos vendedores (caixa+)' })
+  @ApiOperation({
+    summary:
+      'Visualiza o ranking mensal dos vendedores (Caixa, vendedor, gerente ou administrador)',
+  })
   @ApiResponse({ status: 200, description: 'Ranking retornado com sucesso' })
   @ApiResponse({ status: 403, description: 'Acesso negado' })
   getSellersRanking(@Query() query: QueryRankingDto) {
@@ -55,7 +58,7 @@ export class EmployeesController {
   }
 
   @Get(':cpf')
-  @ApiOperation({ summary: 'Busca um funcionário por CPF' })
+  @ApiOperation({ summary: 'Busca um funcionário por CPF (Administrador)' })
   @ApiParam({ name: 'cpf', description: 'CPF (11 dígitos sem máscara)' })
   @ApiResponse({ status: 200, description: 'Funcionário encontrado' })
   @ApiResponse({ status: 404, description: 'Funcionário não encontrado' })
@@ -64,7 +67,7 @@ export class EmployeesController {
   }
 
   @Patch(':cpf')
-  @ApiOperation({ summary: 'Atualiza dados do funcionário' })
+  @ApiOperation({ summary: 'Atualiza dados do funcionário (Administrador)' })
   @ApiParam({ name: 'cpf', description: 'CPF (11 dígitos sem máscara)' })
   @ApiResponse({ status: 200, description: 'Funcionário atualizado' })
   @ApiResponse({ status: 404, description: 'Funcionário não encontrado' })

--- a/src/images/images.controller.ts
+++ b/src/images/images.controller.ts
@@ -40,7 +40,7 @@ export class ImagesController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.GERENTE, Role.ADMINISTRADOR)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Registra uma URL de imagem manualmente' })
+  @ApiOperation({ summary: 'Registra uma URL de imagem manualmente (Gerente ou administrador)' })
   @ApiResponse({ status: 201, description: 'Imagem registrada com sucesso' })
   @ApiResponse({ status: 400, description: 'Payload inválido' })
   createImage(@Body() dto: CreateImageDto) {
@@ -67,7 +67,10 @@ export class ImagesController {
       },
     }),
   )
-  @ApiOperation({ summary: 'Faz upload de uma imagem para o ImgBB e salva a URL no banco' })
+  @ApiOperation({
+    summary:
+      'Faz upload de uma imagem para o ImgBB e salva a URL no banco (Gerente ou administrador)',
+  })
   @ApiConsumes('multipart/form-data')
   @ApiBody({
     schema: {
@@ -102,7 +105,9 @@ export class ImagesController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.GERENTE, Role.ADMINISTRADOR)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Vincula uma imagem a uma variante de produto' })
+  @ApiOperation({
+    summary: 'Vincula uma imagem a uma variante de produto (Gerente ou administrador)',
+  })
   @ApiResponse({ status: 201, description: 'Imagem vinculada ao catálogo' })
   @ApiResponse({ status: 400, description: 'Payload inválido' })
   @ApiResponse({ status: 404, description: 'Imagem ou variante não encontrada' })
@@ -111,7 +116,7 @@ export class ImagesController {
   }
 
   @Get('catalog/:variantSku')
-  @ApiOperation({ summary: 'Lista imagens de catálogo de uma variante' })
+  @ApiOperation({ summary: 'Lista imagens de catálogo de uma variante (Público)' })
   @ApiParam({ name: 'variantSku', type: String })
   @ApiResponse({ status: 200, description: 'Imagens de catálogo da variante' })
   @ApiResponse({ status: 404, description: 'Variante não encontrada' })

--- a/src/inventory/inventory.controller.ts
+++ b/src/inventory/inventory.controller.ts
@@ -34,7 +34,7 @@ export class InventoryController {
   constructor(private readonly inventoryService: InventoryService) {}
 
   @Get(':sku')
-  @ApiOperation({ summary: 'Consulta disponibilidade de estoque de uma variante (público)' })
+  @ApiOperation({ summary: 'Consulta disponibilidade de estoque de uma variante (Público)' })
   @ApiParam({ name: 'sku', description: 'Código SKU da variante' })
   @ApiResponse({ status: 200, description: 'Quantidades em estoque' })
   @ApiResponse({ status: 404, description: 'Variante não encontrada' })
@@ -47,7 +47,7 @@ export class InventoryController {
   @Roles(Role.GERENTE, Role.ADMINISTRADOR)
   @ApiBearerAuth()
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Ajusta o estoque manualmente (gerente/admin)' })
+  @ApiOperation({ summary: 'Ajusta o estoque manualmente (Gerente ou administrador)' })
   @ApiParam({ name: 'sku', description: 'Código SKU da variante' })
   @ApiResponse({ status: 200, description: 'Estoque ajustado' })
   @ApiResponse({ status: 400, description: 'Valor negativo ou payload inválido' })
@@ -65,7 +65,9 @@ export class InventoryController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMINISTRADOR)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Histórico de movimentações de estoque de uma variante (admin)' })
+  @ApiOperation({
+    summary: 'Histórico de movimentações de estoque de uma variante (Administrador)',
+  })
   @ApiParam({ name: 'sku', description: 'Código SKU da variante' })
   @ApiQuery({ name: 'page', required: false, example: 1 })
   @ApiQuery({ name: 'limit', required: false, example: 50 })

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -34,7 +34,7 @@ export class OrdersController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.GERENTE, Role.ADMINISTRADOR)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Lista pedidos paginados com filtros (Gerente+)' })
+  @ApiOperation({ summary: 'Lista pedidos paginados com filtros (Gerente ou administrador)' })
   @ApiResponse({ status: 200, description: 'Lista paginada de pedidos' })
   @ApiResponse({ status: 401, description: 'Não autenticado' })
   @ApiResponse({ status: 403, description: 'Acesso negado (Requer Gerente+)' })
@@ -45,7 +45,9 @@ export class OrdersController {
   @Get('my')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Lista os próprios pedidos do cliente autenticado (paginado)' })
+  @ApiOperation({
+    summary: 'Lista os próprios pedidos do cliente autenticado (Cliente autenticado)',
+  })
   @ApiResponse({ status: 200, description: 'Lista paginada dos pedidos do cliente' })
   @ApiResponse({ status: 401, description: 'Não autenticado' })
   findMy(@CurrentUser() user: CurrentUserPayload, @Query() query: ListOrdersQueryDto) {
@@ -56,7 +58,7 @@ export class OrdersController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Cria um novo pedido (Checkout Online)' })
+  @ApiOperation({ summary: 'Cria um novo pedido (Cliente autenticado)' })
   @ApiResponse({ status: 201, description: 'Pedido criado com sucesso' })
   @ApiResponse({ status: 400, description: 'Cupom inválido ou dados incorretos' })
   @ApiResponse({ status: 401, description: 'Não autenticado' })
@@ -70,7 +72,9 @@ export class OrdersController {
   @Roles(Role.CAIXA, Role.GERENTE, Role.ADMINISTRADOR)
   @ApiBearerAuth()
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Registra uma nova venda presencial no caixa (Caixa+)' })
+  @ApiOperation({
+    summary: 'Registra uma nova venda presencial no caixa (Caixa, gerente ou administrador)',
+  })
   @ApiResponse({ status: 201, description: 'Venda presencial registrada com sucesso' })
   @ApiResponse({
     status: 400,
@@ -91,7 +95,10 @@ export class OrdersController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.VENDEDOR, Role.GERENTE, Role.ADMINISTRADOR)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Insere manualmente o código de rastreamento de frete (Vendedor+)' })
+  @ApiOperation({
+    summary:
+      'Insere manualmente o código de rastreamento de frete (Vendedor, gerente ou administrador)',
+  })
   @ApiParam({ name: 'id', description: 'ID do pedido' })
   @ApiResponse({
     status: 200,
@@ -109,7 +116,8 @@ export class OrdersController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({
-    summary: 'Consulta os detalhes de um pedido específico (Autenticado, Dono ou Funcionário)',
+    summary:
+      'Consulta os detalhes de um pedido específico (Cliente autenticado, dono do pedido ou funcionário)',
   })
   @ApiParam({ name: 'id', description: 'ID do pedido' })
   @ApiResponse({ status: 200, description: 'Detalhes do pedido retornados com sucesso' })
@@ -123,7 +131,10 @@ export class OrdersController {
   @Get(':id/verification-code')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Recupera o código de verificação para retirada na loja física' })
+  @ApiOperation({
+    summary:
+      'Recupera o código de verificação para retirada na loja física (Cliente autenticado, dono do pedido ou funcionário)',
+  })
   @ApiParam({ name: 'id', description: 'ID do pedido' })
   @ApiResponse({ status: 200, description: 'Código retornado com sucesso' })
   @ApiResponse({ status: 400, description: 'Pedido não está configurado para retirada na loja' })
@@ -143,7 +154,8 @@ export class OrdersController {
   @ApiBearerAuth()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
-    summary: 'Confirma a retirada física de um pedido pelo cliente via validação do PIN (Caixa+)',
+    summary:
+      'Confirma a retirada física de um pedido pelo cliente via validação do PIN (Caixa, gerente ou administrador)',
   })
   @ApiParam({ name: 'id', description: 'ID do pedido' })
   @ApiResponse({

--- a/src/payments/payments.controller.ts
+++ b/src/payments/payments.controller.ts
@@ -26,7 +26,9 @@ export class PaymentsController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Registra tentativa de pagamento de um pedido (Autenticado, Dono)' })
+  @ApiOperation({
+    summary: 'Registra tentativa de pagamento de um pedido (Cliente autenticado, dono do pedido)',
+  })
   @ApiResponse({ status: 201, description: 'Pagamento registrado com sucesso' })
   @ApiResponse({ status: 400, description: 'Dados de validação incorretos ou pedido não pendente' })
   @ApiResponse({ status: 401, description: 'Não autenticado' })
@@ -41,7 +43,8 @@ export class PaymentsController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({
-    summary: 'Consulta o status de pagamento do pedido (Autenticado, Dono ou Funcionário)',
+    summary:
+      'Consulta o status de pagamento do pedido (Cliente autenticado, dono do pedido ou funcionário)',
   })
   @ApiParam({ name: 'idPedido', description: 'ID do pedido a ser consultado' })
   @ApiResponse({ status: 200, description: 'Detalhes do pagamento retornados com sucesso' })
@@ -58,7 +61,7 @@ export class PaymentsController {
   @Post('webhook')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
-    summary: 'Webhook para processamento de notificações de pagamento da InfinitePay',
+    summary: 'Webhook para processamento de notificações de pagamento da InfinitePay (Público)',
   })
   @ApiResponse({ status: 200, description: 'Webhook processado com sucesso' })
   @ApiResponse({ status: 404, description: 'Pagamento associado não encontrado' })

--- a/src/people/people.controller.ts
+++ b/src/people/people.controller.ts
@@ -69,7 +69,9 @@ export class PeopleController {
 
   @Post('register-person')
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Registra uma pessoa na loja (funcionário caixa)' })
+  @ApiOperation({
+    summary: 'Registra uma pessoa na loja (Caixa, vendedor, gerente ou administrador)',
+  })
   @ApiResponse({ status: 201, description: 'Pessoa registrada com sucesso' })
   @ApiResponse({ status: 400, description: 'Payload inválido' })
   @ApiResponse({ status: 409, description: 'Email já cadastrado' })
@@ -82,21 +84,23 @@ export class PeopleController {
 
   @Post('register-user')
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Registra um usuário no site (auto-cadastro)' })
+  @ApiOperation({ summary: 'Registra um usuário no site (Público)' })
   @ApiResponse({ status: 201, description: 'Usuário registrado com sucesso' })
   @ApiResponse({ status: 400, description: 'Payload inválido' })
   @ApiResponse({ status: 409, description: 'Email já cadastrado ou CPF já possui conta completa' })
+  @ApiBearerAuth()
   registerUser(@Body() dto: RegisterUserDto) {
     return this.peopleService.registerUser(dto);
   }
 
   @Get()
-  @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Lista pessoas com paginação' })
+  @ApiOperation({ summary: 'Lista pessoas com paginação (Funcionários)' })
   @ApiQuery({ name: 'page', required: false, example: 1 })
   @ApiQuery({ name: 'limit', required: false, example: 20 })
   @ApiResponse({ status: 200, description: 'Lista paginada de pessoas' })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.CAIXA, Role.VENDEDOR, Role.GERENTE, Role.ADMINISTRADOR)
   findAll(@Query() query: PaginationDto) {
     return this.peopleService.findAll(query.page, query.limit);
   }
@@ -104,7 +108,7 @@ export class PeopleController {
   @Get(':cpf')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Busca uma pessoa por CPF' })
+  @ApiOperation({ summary: 'Busca uma pessoa por CPF (Cliente autenticado)' })
   @ApiParam({ name: 'cpf', description: 'CPF (11 dígitos sem máscara)' })
   @ApiResponse({ status: 200, description: 'Pessoa encontrada' })
   @ApiResponse({ status: 404, description: 'Pessoa não encontrada' })
@@ -115,7 +119,7 @@ export class PeopleController {
   @Patch(':cpf')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Atualiza dados de uma pessoa' })
+  @ApiOperation({ summary: 'Atualiza dados de uma pessoa (Cliente autenticado)' })
   @ApiParam({ name: 'cpf', description: 'CPF (11 dígitos sem máscara)' })
   @ApiResponse({ status: 200, description: 'Pessoa atualizada' })
   @ApiResponse({ status: 404, description: 'Pessoa não encontrada' })
@@ -128,7 +132,7 @@ export class PeopleController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @HttpCode(HttpStatus.NO_CONTENT)
-  @ApiOperation({ summary: 'Remove uma pessoa' })
+  @ApiOperation({ summary: 'Remove uma pessoa (Cliente autenticado)' })
   @ApiParam({ name: 'cpf', description: 'CPF (11 dígitos sem máscara)' })
   @ApiResponse({ status: 204, description: 'Pessoa removida' })
   @ApiResponse({ status: 404, description: 'Pessoa não encontrada' })

--- a/src/product-variants/product-variants.controller.ts
+++ b/src/product-variants/product-variants.controller.ts
@@ -39,7 +39,7 @@ export class ProductVariantsController {
   @Roles(Role.GERENTE, Role.ADMINISTRADOR)
   @ApiBearerAuth()
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Cria uma variante de produto' })
+  @ApiOperation({ summary: 'Cria uma variante de produto (Gerente ou administrador)' })
   @ApiResponse({ status: 201, description: 'Variante criada com sucesso' })
   @ApiResponse({ status: 400, description: 'Payload inválido' })
   @ApiResponse({ status: 404, description: 'Produto não encontrado' })
@@ -48,7 +48,7 @@ export class ProductVariantsController {
   }
 
   @Get()
-  @ApiOperation({ summary: 'Lista variantes de produto' })
+  @ApiOperation({ summary: 'Lista variantes de produto (Público)' })
   @ApiQuery({ name: 'page', required: false, example: 1 })
   @ApiQuery({ name: 'limit', required: false, example: 20 })
   @ApiQuery({ name: 'ativo', required: false, type: Boolean })
@@ -58,7 +58,7 @@ export class ProductVariantsController {
   }
 
   @Get(':sku')
-  @ApiOperation({ summary: 'Busca uma variante por SKU' })
+  @ApiOperation({ summary: 'Busca uma variante por SKU (Público)' })
   @ApiParam({ name: 'sku', type: String })
   @ApiResponse({ status: 200, description: 'Variante encontrada' })
   @ApiResponse({ status: 404, description: 'Variante não encontrada' })
@@ -70,7 +70,7 @@ export class ProductVariantsController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.GERENTE, Role.ADMINISTRADOR)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Atualiza uma variante' })
+  @ApiOperation({ summary: 'Atualiza uma variante (Gerente ou administrador)' })
   @ApiParam({ name: 'sku', type: String })
   @ApiResponse({ status: 200, description: 'Variante atualizada' })
   @ApiResponse({ status: 400, description: 'Payload inválido' })
@@ -84,7 +84,7 @@ export class ProductVariantsController {
   @Roles(Role.ADMINISTRADOR)
   @ApiBearerAuth()
   @HttpCode(HttpStatus.NO_CONTENT)
-  @ApiOperation({ summary: 'Remove uma variante' })
+  @ApiOperation({ summary: 'Remove uma variante (Administrador)' })
   @ApiParam({ name: 'sku', type: String })
   @ApiResponse({ status: 204, description: 'Variante removida' })
   @ApiResponse({ status: 404, description: 'Variante não encontrada' })

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -40,7 +40,7 @@ export class ProductsController {
   @Roles(Role.GERENTE, Role.ADMINISTRADOR)
   @ApiBearerAuth()
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Cria um produto' })
+  @ApiOperation({ summary: 'Cria um produto (Gerente ou administrador)' })
   @ApiResponse({ status: 201, description: 'Produto criado com sucesso' })
   @ApiResponse({ status: 400, description: 'Payload inválido' })
   create(@Body() dto: CreateProductDto) {
@@ -48,7 +48,7 @@ export class ProductsController {
   }
 
   @Get()
-  @ApiOperation({ summary: 'Lista produtos com paginação e filtros' })
+  @ApiOperation({ summary: 'Lista produtos com paginação e filtros (Público)' })
   @ApiQuery({ name: 'page', required: false, example: 1 })
   @ApiQuery({ name: 'limit', required: false, example: 20 })
   @ApiQuery({ name: 'categoryId', required: false, type: Number })
@@ -61,7 +61,7 @@ export class ProductsController {
   }
 
   @Get(':id')
-  @ApiOperation({ summary: 'Busca um produto por id' })
+  @ApiOperation({ summary: 'Busca um produto por id (Público)' })
   @ApiParam({ name: 'id', type: Number })
   @ApiResponse({ status: 200, description: 'Produto encontrado' })
   @ApiResponse({ status: 404, description: 'Produto não encontrado' })
@@ -73,7 +73,7 @@ export class ProductsController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.GERENTE, Role.ADMINISTRADOR)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Atualiza um produto' })
+  @ApiOperation({ summary: 'Atualiza um produto (Gerente ou administrador)' })
   @ApiParam({ name: 'id', type: Number })
   @ApiResponse({ status: 200, description: 'Produto atualizado' })
   @ApiResponse({ status: 400, description: 'Payload inválido' })
@@ -87,7 +87,7 @@ export class ProductsController {
   @Roles(Role.ADMINISTRADOR)
   @ApiBearerAuth()
   @HttpCode(HttpStatus.NO_CONTENT)
-  @ApiOperation({ summary: 'Remove um produto' })
+  @ApiOperation({ summary: 'Remove um produto (Administrador)' })
   @ApiParam({ name: 'id', type: Number })
   @ApiResponse({ status: 204, description: 'Produto removido' })
   @ApiResponse({ status: 404, description: 'Produto não encontrado' })
@@ -99,7 +99,7 @@ export class ProductsController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.GERENTE, Role.ADMINISTRADOR)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Associa uma categoria a um produto' })
+  @ApiOperation({ summary: 'Associa uma categoria a um produto (Gerente ou administrador)' })
   @ApiParam({ name: 'id', type: Number })
   @ApiParam({ name: 'categoryId', type: Number })
   @ApiResponse({ status: 201, description: 'Categoria associada ao produto' })
@@ -115,7 +115,7 @@ export class ProductsController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.GERENTE, Role.ADMINISTRADOR)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Remove uma categoria de um produto' })
+  @ApiOperation({ summary: 'Remove uma categoria de um produto (Gerente ou administrador)' })
   @ApiParam({ name: 'id', type: Number })
   @ApiParam({ name: 'categoryId', type: Number })
   @ApiResponse({ status: 200, description: 'Categoria removida do produto' })

--- a/src/reviews/reviews.controller.ts
+++ b/src/reviews/reviews.controller.ts
@@ -37,7 +37,9 @@ export class ReviewsController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Cria uma nova avaliação de produto pelo cliente autenticado' })
+  @ApiOperation({
+    summary: 'Cria uma nova avaliação de produto pelo cliente autenticado (Cliente autenticado)',
+  })
   @ApiResponse({ status: 201, description: 'Avaliação criada com sucesso' })
   @ApiResponse({ status: 400, description: 'Dados de entrada inválidos' })
   @ApiResponse({ status: 401, description: 'Não autorizado' })
@@ -49,7 +51,7 @@ export class ReviewsController {
   }
 
   @Get('product/:productId')
-  @ApiOperation({ summary: 'Busca as avaliações de um produto por ID (paginado)' })
+  @ApiOperation({ summary: 'Busca as avaliações de um produto por ID (paginado) (Público)' })
   @ApiParam({ name: 'productId', description: 'ID do produto' })
   @ApiQuery({ name: 'page', required: false, example: 1 })
   @ApiQuery({ name: 'limit', required: false, example: 10 })
@@ -70,7 +72,7 @@ export class ReviewsController {
   @Roles(Role.GERENTE, Role.ADMINISTRADOR)
   @ApiBearerAuth()
   @HttpCode(HttpStatus.NO_CONTENT)
-  @ApiOperation({ summary: 'Remove uma avaliação inadequada (Gerente/Administrador)' })
+  @ApiOperation({ summary: 'Remove uma avaliação inadequada (Gerente ou administrador)' })
   @ApiParam({ name: 'clienteId', description: 'CPF do cliente que realizou a avaliação' })
   @ApiParam({ name: 'produtoId', description: 'ID do produto avaliado' })
   @ApiResponse({ status: 204, description: 'Avaliação removida com sucesso (Hard Delete)' })

--- a/src/shipping/shipping.controller.ts
+++ b/src/shipping/shipping.controller.ts
@@ -12,7 +12,7 @@ export class ShippingController {
   @Post('calculate')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
-    summary: 'Calcula o frete para um CEP de destino',
+    summary: 'Calcula o frete para um CEP de destino (Público)',
     description:
       'Recebe o CEP de destino (8 dígitos) e, opcionalmente, peso e dimensões ' +
       'do pacote. Retorna o valor do frete e o prazo estimado em dias úteis.',


### PR DESCRIPTION
This pull request updates the OpenAPI documentation summaries across multiple controllers to clarify the required user roles or public accessibility for each endpoint. The changes make it easier for developers and API consumers to understand which endpoints are public and which require specific roles, improving the overall clarity and usability of the API documentation.

**API Documentation Improvements:**

* Added explicit role or access level information to `@ApiOperation` summaries for endpoints in the following controllers:
  - [`AuthController`](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9L14-R14): Clarified the login endpoint as public.
  - [`CategoriesController`](diffhunk://#diff-8af8535932a3e1bc08a9eb9e07c3525a35bf72f849647833dd3b28a6eb0ebcccL43-R51): Marked endpoints as "Público" or "Administrador" as appropriate for create, list, get by id, update, and delete operations. [[1]](diffhunk://#diff-8af8535932a3e1bc08a9eb9e07c3525a35bf72f849647833dd3b28a6eb0ebcccL43-R51) [[2]](diffhunk://#diff-8af8535932a3e1bc08a9eb9e07c3525a35bf72f849647833dd3b28a6eb0ebcccL60-R60) [[3]](diffhunk://#diff-8af8535932a3e1bc08a9eb9e07c3525a35bf72f849647833dd3b28a6eb0ebcccL72-R72) [[4]](diffhunk://#diff-8af8535932a3e1bc08a9eb9e07c3525a35bf72f849647833dd3b28a6eb0ebcccL86-R86)
  - [`CouponsController`](diffhunk://#diff-d8df8a607b20f1b336a2da73081628039b7851406d0760e1db16041ec413e059L83-R85): Clarified public validation endpoint.
  - [`EmployeesController`](diffhunk://#diff-34c48f318a23ea417b0c2021c78d149593feb32e05cfbf9d5db9c54f0d34e25dL30-R30): Clarified which endpoints require "Administrador" or other roles, and improved descriptions for ranking and get-by-CPF endpoints. [[1]](diffhunk://#diff-34c48f318a23ea417b0c2021c78d149593feb32e05cfbf9d5db9c54f0d34e25dL30-R30) [[2]](diffhunk://#diff-34c48f318a23ea417b0c2021c78d149593feb32e05cfbf9d5db9c54f0d34e25dL40-R40) [[3]](diffhunk://#diff-34c48f318a23ea417b0c2021c78d149593feb32e05cfbf9d5db9c54f0d34e25dL50-R61) [[4]](diffhunk://#diff-34c48f318a23ea417b0c2021c78d149593feb32e05cfbf9d5db9c54f0d34e25dL67-R70)
  - [`ImagesController`](diffhunk://#diff-e988fbf58ddd9e8d835a865d2a0561cb9d40fe2321130d376ace2d2ad346a508L43-R43): Clarified access levels for image creation, upload, variant linking, and catalog listing endpoints. [[1]](diffhunk://#diff-e988fbf58ddd9e8d835a865d2a0561cb9d40fe2321130d376ace2d2ad346a508L43-R43) [[2]](diffhunk://#diff-e988fbf58ddd9e8d835a865d2a0561cb9d40fe2321130d376ace2d2ad346a508L70-R73) [[3]](diffhunk://#diff-e988fbf58ddd9e8d835a865d2a0561cb9d40fe2321130d376ace2d2ad346a508L105-R110) [[4]](diffhunk://#diff-e988fbf58ddd9e8d835a865d2a0561cb9d40fe2321130d376ace2d2ad346a508L114-R119)
  - [`InventoryController`](diffhunk://#diff-68d849c814cc6166bebe28d0e74f72d7c87abc76d4bdc969cb7ab36fd60942bdL37-R37): Clarified which endpoints are public, for "Gerente ou administrador", or "Administrador". [[1]](diffhunk://#diff-68d849c814cc6166bebe28d0e74f72d7c87abc76d4bdc969cb7ab36fd60942bdL37-R37) [[2]](diffhunk://#diff-68d849c814cc6166bebe28d0e74f72d7c87abc76d4bdc969cb7ab36fd60942bdL50-R50) [[3]](diffhunk://#diff-68d849c814cc6166bebe28d0e74f72d7c87abc76d4bdc969cb7ab36fd60942bdL68-R70)
  - [`OrdersController`](diffhunk://#diff-0b1cdada28abe665a7bafa5b48540eba4a5c8094cc8e797c1d194e71be9dc0b1L37-R37): Updated summaries to specify "Gerente ou administrador", "Cliente autenticado", and other role-based access for various order operations. [[1]](diffhunk://#diff-0b1cdada28abe665a7bafa5b48540eba4a5c8094cc8e797c1d194e71be9dc0b1L37-R37) [[2]](diffhunk://#diff-0b1cdada28abe665a7bafa5b48540eba4a5c8094cc8e797c1d194e71be9dc0b1L48-R50) [[3]](diffhunk://#diff-0b1cdada28abe665a7bafa5b48540eba4a5c8094cc8e797c1d194e71be9dc0b1L59-R61) [[4]](diffhunk://#diff-0b1cdada28abe665a7bafa5b48540eba4a5c8094cc8e797c1d194e71be9dc0b1L73-R77) [[5]](diffhunk://#diff-0b1cdada28abe665a7bafa5b48540eba4a5c8094cc8e797c1d194e71be9dc0b1L94-R101) [[6]](diffhunk://#diff-0b1cdada28abe665a7bafa5b48540eba4a5c8094cc8e797c1d194e71be9dc0b1L112-R120) [[7]](diffhunk://#diff-0b1cdada28abe665a7bafa5b48540eba4a5c8094cc8e797c1d194e71be9dc0b1L126-R137) [[8]](diffhunk://#diff-0b1cdada28abe665a7bafa5b48540eba4a5c8094cc8e797c1d194e71be9dc0b1L146-R158)
  - [`PaymentsController`](diffhunk://#diff-4e1e81efce92bdaa359939ace2f3ab2a186e26083997263de1be8735ccd3fac8L29-R31): Clarified which endpoints are public, for authenticated clients, or for owners/employees. [[1]](diffhunk://#diff-4e1e81efce92bdaa359939ace2f3ab2a186e26083997263de1be8735ccd3fac8L29-R31) [[2]](diffhunk://#diff-4e1e81efce92bdaa359939ace2f3ab2a186e26083997263de1be8735ccd3fac8L44-R47) [[3]](diffhunk://#diff-4e1e81efce92bdaa359939ace2f3ab2a186e26083997263de1be8735ccd3fac8L61-R64)
  - [`PeopleController`](diffhunk://#diff-7cfd55da49435f58abd9bebe3f075c618d916e3455d5143278c21778e2712bbbL72-R74): Clarified roles required for person registration.

These changes are documentation-only and do not affect application logic.… clarity and consistency