### PR TITLE
feat: add CD workflow and improve Makefile setup

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,91 @@
+name: CD
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: CI passed 
+        run: echo "CI workflow concluído com sucesso — prosseguindo com CD."
+
+  docker:
+    name: Docker Build & Push
+    runs-on: ubuntu-latest
+    needs: gate
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Tag "latest" para todo push na main
+            type=raw,value=latest,enable={{is_default_branch}}
+            # Tag com SHA curto para rastreabilidade exata
+            type=sha,prefix=sha-,format=short
+            # Tag semver se houver git tag (ex: v1.0.0 → 1.0.0, 1.0, 1)
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runner
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: false
+
+      - name: Print image summary
+        run: |
+          echo "## Docker Image Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Registry:** \`${{ env.REGISTRY }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Tags" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** \`${{ github.event.workflow_run.head_sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Triggered by:** CI workflow #${{ github.event.workflow_run.run_number }}" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export COMPOSE_DOCKER_CLI_BUILD := 1
 	dev-lint dev-lint-fix dev-format dev-typecheck dev-check dev-openapi \
 	prod-up prod-down prod-logs prod-build prod-rebuild \
 	db-shell db-reset db-backup \
-	clean check
+	clean check ci-local docker-build
 
 help:
 	@echo "Setup e local:"
@@ -65,6 +65,10 @@ help:
 	@echo "  make gen-secrets      Gera JWT_SECRET aleatorio nos arquivos .env"
 	@echo "  make clean            Remove artefatos locais de build"
 	@echo "  make check            Verifica se o Dockerfile esta correto"
+	@echo ""
+	@echo "CI/CD:"
+	@echo "  make ci-local         Roda lint + typecheck + format:check + testes (espelha o CI)"
+	@echo "  make docker-build     Builda a imagem Docker de producao standalone (espelha o CD)"
 
 env-setup:
 	cp -n .env.development.example .env.development || true
@@ -204,3 +208,13 @@ clean:
 
 check:
 	docker build . --check
+
+ci-local:
+	pnpm lint
+	pnpm typecheck
+	pnpm format:check
+	pnpm build
+	pnpm test
+
+docker-build:
+	docker build --target runner -t marketplace-backend:local .

--- a/docs/cd.md
+++ b/docs/cd.md
@@ -1,483 +1,132 @@
-# Continuous Delivery (CD) — MarketPlace Backend
+# Continuous Delivery — DK Fashion
 
-> Documentação completa do pipeline de Continuous Delivery do projeto MarketPlace Backend (DK Fashion).
+Como funciona o pipeline de CD (`.github/workflows/cd.yml`) e sua relação com o CI.
 
----
+## Visão geral
 
-## Sumário
+O CD automatiza o empacotamento da aplicação em uma imagem Docker de produção
+e a publicação no GitHub Container Registry (GHCR). Ele não duplica o CI —
+assume que lint, typecheck, testes e coverage já passaram e se limita à
+entrega do artefato.
 
-- [1. O que é o CD implementado](#1-o-que-é-o-cd-implementado)
-- [2. Diferença entre CI e CD](#2-diferença-entre-ci-e-cd)
-- [3. Fluxo do Pipeline](#3-fluxo-do-pipeline)
-- [4. Quando o Build/Deploy ocorre](#4-quando-o-builddeploy-ocorre)
-- [5. Tecnologias utilizadas](#5-tecnologias-utilizadas)
-- [6. Estrutura do Workflow](#6-estrutura-do-workflow)
-- [7. Docker — Explicação detalhada](#7-docker--explicação-detalhada)
-- [8. Triggers do GitHub Actions](#8-triggers-do-github-actions)
-- [9. Como executar localmente](#9-como-executar-localmente)
-- [10. Como evoluir o pipeline](#10-como-evoluir-o-pipeline)
-- [11. Referências](#11-referências)
-
----
-
-## 1. O que é o CD implementado
-
-O pipeline de **Continuous Delivery** automatiza o processo de empacotamento da aplicação em uma imagem Docker de produção e sua publicação no **GitHub Container Registry (GHCR)**.
-
-O CD **não duplica** responsabilidades do CI — ele assume que o código já foi validado (lint, typecheck, testes, coverage) e se concentra exclusivamente na entrega do artefato final.
-
-### O que o CD faz
-
-| Etapa | Descrição |
+| Etapa | O que faz |
 |---|---|
-| **Gate** | Verifica se o CI concluiu com sucesso |
-| **Docker Build** | Constrói a imagem de produção com multi-stage build |
-| **Push para GHCR** | Publica a imagem com tags semânticas |
-| **Resumo** | Gera um summary no GitHub Actions com os detalhes da publicação |
+| `gate` | Verifica se o CI concluiu com sucesso |
+| `docker` | Builda a imagem (multi-stage, target `runner`) e publica no GHCR |
 
----
-
-## 2. Diferença entre CI e CD
-
-```mermaid
-graph LR
-    subgraph CI["🔍 CI — Continuous Integration"]
-        A[Lint + Typecheck] --> B[Build]
-        B --> C[Testes Unitários]
-        C --> D[Coverage + Integração]
-    end
-
-    subgraph CD["🚀 CD — Continuous Delivery"]
-        E[CI Gate] --> F[Docker Build]
-        F --> G[Push GHCR]
-    end
-
-    CI -->|sucesso na main| CD
-```
+## CI vs CD
 
 | Aspecto | CI | CD |
 |---|---|---|
-| **Objetivo** | Validar qualidade do código | Empacotar e entregar artefato |
-| **Quando executa** | Push e PR em `dev` e `main` | Somente após CI bem-sucedido na `main` |
-| **O que verifica** | Lint, types, testes, coverage | — |
-| **O que produz** | Relatório de coverage | Imagem Docker publicada |
-| **Falha significa** | Código com problemas | Falha no empacotamento |
+| Objetivo | Validar qualidade do código | Empacotar e entregar artefato |
+| Quando executa | Push e PR em `dev` e `main` | Somente após CI com sucesso na `main` |
+| O que produz | Relatório de coverage | Imagem Docker publicada |
 
-> **Princípio:** O CI é o guardião da qualidade. O CD é o entregador — ele confia no CI.
+## Quando o CD executa
 
----
+O CD é acionado exclusivamente quando um push na `main` faz o CI concluir
+com sucesso. O GitHub Actions dispara o evento `workflow_run`:
 
-## 3. Quando o Build/Deploy ocorre
+```yaml
+on:
+  workflow_run:
+    workflows: ["CI"]      # nome exato do workflow de CI
+    types: [completed]     # dispara ao finalizar (sucesso ou falha)
+    branches: [main]       # somente na main
+```
 
-O CD é acionado **exclusivamente** quando:
-
-1. Um **push** é feito na branch `main`
-2. O **CI completa com sucesso** para esse push
-3. O GitHub Actions dispara o evento `workflow_run`
-
-### Cenários
+O `workflow_run` dispara mesmo quando o CI falha. Por isso o job `gate`
+verifica `conclusion == 'success'` antes de prosseguir.
 
 | Cenário | CI roda? | CD roda? |
 |---|---|---|
-| Push na `dev` | ✅ | ❌ |
-| PR para `main` | ✅ | ❌ |
-| Push na `main` + CI falha | ✅ | ❌ |
-| Push na `main` + CI passa | ✅ | ✅ |
-| Tag semver na `main` + CI passa | ✅ | ✅ (com tags de versão) |
+| Push na `dev` | sim | nao |
+| PR para `main` | sim | nao |
+| Push na `main` + CI falha | sim | nao |
+| Push na `main` + CI passa | sim | sim |
+| Tag semver na `main` + CI passa | sim | sim (com tags de versao) |
 
-### Tags geradas na imagem
+## Tags geradas
 
 | Tipo | Exemplo | Quando |
 |---|---|---|
 | `latest` | `ghcr.io/org/repo:latest` | Todo push na `main` |
 | `sha-*` | `ghcr.io/org/repo:sha-a1b2c3d` | Todo push na `main` |
-| `semver` | `ghcr.io/org/repo:1.2.3` | Quando há tag git `v1.2.3` |
+| semver | `ghcr.io/org/repo:1.2.3` | Quando ha tag git `v1.2.3` |
 
----
+## Docker multi-stage
 
-## 4. Tecnologias utilizadas
+O Dockerfile usa 5 estagios. O CD builda apenas o target `runner`:
 
-| Tecnologia | Propósito | Versão |
+| Estagio | Proposito | Na imagem final? |
 |---|---|---|
-| **GitHub Actions** | Plataforma de CI/CD | v2 (workflow syntax) |
-| **Docker** | Containerização da aplicação | Buildx multi-platform |
-| **GHCR** | Registry de imagens Docker | Integrado ao GitHub |
-| **Node.js** | Runtime da aplicação | 22-alpine |
-| **pnpm** | Gerenciador de pacotes | 10.33.0 |
-| **NestJS** | Framework backend | Dockerfile multi-stage |
+| `base` | Node 22-alpine + corepack | sim (base) |
+| `deps` | Instala todas as dependencias | nao |
+| `dev` | Ambiente de desenvolvimento | nao |
+| `prod-deps` | Instala apenas deps de producao | sim (node_modules) |
+| `build` | Compila TypeScript → JavaScript | sim (dist/) |
+| `runner` | Imagem final otimizada | sim |
 
-### Actions utilizadas
+A imagem final contem apenas `dist/`, `node_modules` de producao e
+`package.json`. Roda como usuario nao-root (`nestjs:nodejs`), com
+healthcheck embutido (`/api/health`).
 
-| Action | Versão | Propósito |
-|---|---|---|
-| `actions/checkout` | v4 | Checkout do código |
-| `docker/setup-buildx-action` | v3 | Setup do Buildx para cache avançado |
-| `docker/login-action` | v3 | Autenticação no GHCR |
-| `docker/metadata-action` | v5 | Geração automática de tags e labels |
-| `docker/build-push-action` | v6 | Build e push da imagem |
+## Por que `workflow_run`
 
----
+Usar `workflow_run` em vez de colocar tudo no `ci.yml`:
 
-## 5. Estrutura do Workflow
+- Separa responsabilidades: CI valida, CD entrega.
+- O CI roda em PRs sem acionar o CD naturalmente.
+- Permissoes isoladas: o CI nao precisa de `packages:write`.
+- Cada pipeline evolui de forma independente.
 
-```yaml
-# Estrutura simplificada do cd.yml
-name: CD
+## Cache
 
-on:
-  workflow_run:           # Trigger encadeado
-    workflows: ["CI"]     # Nome exato do CI
-    types: [completed]    # Quando CI finaliza
-    branches: [main]      # Somente na main
+O build usa `cache-from: type=gha` / `cache-to: type=gha,mode=max`. Isso
+persiste layers Docker entre runs usando o storage nativo do GitHub Actions.
+`mode=max` exporta todas as layers intermediarias para maximo
+reaproveitamento.
 
-permissions:
-  contents: read          # Checkout
-  packages: write         # Push GHCR
-
-jobs:
-  gate:                   # Verifica se CI passou
-    if: conclusion == 'success'
-
-  docker:                 # Build + Push
-    needs: gate
-    steps:
-      - checkout          # SHA exato do CI
-      - setup-buildx      # Cache avançado
-      - login             # GHCR auth
-      - metadata          # Tags automáticas
-      - build-push        # Build + Push com cache
-      - summary           # Resumo no Actions
-```
-
-### Decisões Arquiteturais
-
-#### Por que `workflow_run` em vez de `needs` no mesmo arquivo?
-
-```mermaid
-graph TD
-    subgraph Opção_A["❌ Opção A: Tudo em ci.yml"]
-        A1[lint] --> A2[build]
-        A2 --> A3[test]
-        A3 --> A4[docker]
-        style A4 fill:#d32f2f,color:#fff
-    end
-    
-    subgraph Opção_B["✅ Opção B: workflow_run (escolhida)"]
-        B1["ci.yml (lint, build, test)"]
-        B2["cd.yml (docker)"]
-        B1 -->|workflow_run| B2
-    end
-```
-
-| Critério | Mesmo arquivo | `workflow_run` (escolhido) |
-|---|---|---|
-| Separação de responsabilidades | ❌ Misturado | ✅ Limpo |
-| CI roda em PRs sem acionar CD | ❌ Precisa de condicionais | ✅ Natural |
-| Permissões | ⚠️ Precisa de `packages:write` no CI | ✅ Cada um com suas permissões |
-| Evolução independente | ❌ Acoplado | ✅ Independente |
-
-#### Por que cache GHA (GitHub Actions) para Docker?
-
-- O cache `type=gha` usa o storage nativo do GitHub Actions
-- Não precisa de registry externo para cache
-- `mode=max` exporta todas as layers intermediárias para máximo reaproveitamento
-- Builds subsequentes são significativamente mais rápidos
-
----
-
-## 6. Docker — Explicação detalhada
-
-### Multi-stage Build
-
-O Dockerfile utiliza um build multi-stage com 5 estágios:
-
-```mermaid
-graph TD
-    A["base<br/>Node 22-alpine + corepack"] --> B["deps<br/>pnpm install (todas deps)"]
-    A --> C["prod-deps<br/>pnpm install --prod"]
-    B --> D["dev<br/>Ambiente de desenvolvimento"]
-    B --> E["build<br/>nest build → dist/"]
-    C --> F["runner<br/>Imagem final de produção"]
-    E --> F
-    
-    style F fill:#1565c0,color:#fff,stroke-width:3px
-```
-
-| Estágio | Propósito | Presente na imagem final? |
-|---|---|---|
-| `base` | Imagem base com Node.js e corepack | Sim (base) |
-| `deps` | Instala todas as dependências | Não |
-| `dev` | Ambiente de desenvolvimento | Não |
-| `prod-deps` | Instala apenas deps de produção | Sim (node_modules) |
-| `build` | Compila TypeScript → JavaScript | Sim (dist/) |
-| **`runner`** | **Imagem final otimizada** | **Sim** |
-
-### Imagem Final (`runner`)
-
-A imagem de produção contém apenas:
-
-```
-/app
-├── dist/           # Código compilado (JavaScript)
-├── node_modules/   # Apenas dependências de produção
-└── package.json    # Metadados do pacote
-```
-
-**Características de segurança:**
-
-- Roda como usuário não-root (`nestjs:nodejs`)
-- Base Alpine (superfície de ataque mínima)
-- Healthcheck embutido (endpoint `/api/health`)
-- Sem código-fonte TypeScript, testes ou ferramentas de dev
-
-### Docker Compose — Ambientes
-
-| Arquivo | Ambiente | Target | Uso |
-|---|---|---|---|
-| `compose.dev.yml` | Desenvolvimento | `dev` | Hot-reload, volumes, debug |
-| `compose.prod.yml` | Produção | `runner` | Imagem otimizada, sem volumes |
-
----
-
-## 7. Triggers do GitHub Actions
-
-### CI — Triggers
-
-```yaml
-on:
-  pull_request:
-    branches: [dev, main]    # Valida PRs antes do merge
-  push:
-    branches: [dev, main]    # Valida pushes diretos
-```
-
-### CD — Trigger
-
-```yaml
-on:
-  workflow_run:
-    workflows: ["CI"]        # Encadeia com o CI
-    types: [completed]       # Quando o CI finaliza (sucesso ou falha)
-    branches: [main]         # Somente na branch main
-```
-
-> **Importante:** O `workflow_run` dispara quando o CI **finaliza** (não necessariamente com sucesso). Por isso o job `gate` verifica explicitamente `conclusion == 'success'`.
-
-```mermaid
-sequenceDiagram
-    participant Dev as Developer
-    participant GH as GitHub
-    participant CI as CI Workflow
-    participant CD as CD Workflow
-    participant GHCR as GHCR Registry
-    
-    Dev->>GH: git push main
-    GH->>CI: Trigger: push event
-    CI->>CI: lint + typecheck
-    CI->>CI: build
-    CI->>CI: test + coverage
-    CI-->>GH: ✅ Conclusion: success
-    GH->>CD: Trigger: workflow_run (completed)
-    CD->>CD: Gate: verifica conclusion == success
-    CD->>CD: Docker build (multi-stage)
-    CD->>GHCR: Push imagem com tags
-    CD-->>GH: 📋 Summary com detalhes
-```
-
----
-
-## 8. Como executar localmente
-
-### Pré-requisitos
-
-- Docker Desktop ou Docker Engine instalado
-- Acesso ao repositório
-
-### Build local da imagem de produção
+## Como testar localmente
 
 ```bash
-# Build simples da imagem de produção
+# Espelha o CI
+make ci-local
+
+# Espelha o CD (build Docker standalone, mesmo target do workflow)
+make docker-build
+
+# Ou via Docker direto
 docker build --target runner -t marketplace-backend:local .
 
-# Build com verificação de sintaxe do Dockerfile
-docker build . --check
+# Verificar que a imagem roda
+docker run --rm marketplace-backend:local node -e "console.log('OK')"
 
-# Build via Makefile (recomendado)
-make prod-build
-```
-
-### Rodando a imagem localmente
-
-```bash
-# Via Docker direto
-docker run --rm -p 3000:3000 \
-  -e NODE_ENV=production \
-  -e PORT=3000 \
-  -e POSTGRES_HOST=host.docker.internal \
-  -e POSTGRES_PORT=5432 \
-  -e POSTGRES_USER=seu_user \
-  -e POSTGRES_PASSWORD=sua_senha \
-  -e POSTGRES_DB=seu_banco \
-  -e JWT_SECRET=$(openssl rand -base64 32) \
-  marketplace-backend:local
-
-# Via Docker Compose (recomendado)
+# Via Docker Compose (com banco e envs)
 make prod-up
 ```
 
-### Simulando o pipeline completo localmente
+## Evoluindo o pipeline
 
-```bash
-# 1. Rodar CI localmente
-make lint                    # Lint
-pnpm typecheck               # Typecheck
-pnpm build                   # Build
-pnpm test                    # Testes unitários
-pnpm test:cov                # Coverage
+Sugestoes para futuras equipes:
 
-# 2. Se tudo passou, buildar imagem Docker
-docker build --target runner -t marketplace-backend:local .
+- **Deploy staging**: adicionar job `deploy-staging` com `environment: staging`
+  e pull da imagem no servidor.
+- **Aprovacao manual**: usar GitHub Environments com protection rules para
+  exigir aprovacao antes de deploy em producao.
+- **Smoke tests**: job pos-deploy que faz `curl --fail` no healthcheck.
+- **Notificacoes**: integrar Discord/Slack com
+  `sarisia/actions-status-discord`.
+- **Multi-arch**: adicionar `platforms: linux/amd64,linux/arm64` no
+  build-push-action.
+- **Vulnerability scanning**: Trivy ou Grype na imagem antes do push.
 
-# 3. Verificar que a imagem funciona
-docker run --rm marketplace-backend:local node -e "console.log('OK')"
-```
+## Referencia rapida
 
-### Testando com o act (GitHub Actions local)
-
-```bash
-# Instalar o act (https://github.com/nektos/act)
-# O act simula GitHub Actions localmente
-
-# Listar workflows disponíveis
-act -l
-
-# Rodar apenas o build Docker (sem push)
-act workflow_run -W .github/workflows/cd.yml --dryrun
-```
-
----
-
-## 10. Como evoluir o pipeline
-
-### Próximos passos sugeridos
-
-```mermaid
-graph LR
-    A["Atual<br/>Build + Push GHCR"] --> B["Deploy Staging"]
-    B --> C["Smoke Tests"]
-    C --> D["Deploy Produção"]
-    D --> E["Monitoramento"]
-    
-    style A fill:#1565c0,color:#fff
-    style B fill:#7b1fa2,color:#fff
-    style C fill:#e65100,color:#fff
-    style D fill:#2e7d32,color:#fff
-    style E fill:#f57f17,color:#000
-```
-
-### 1. Deploy automático para staging
-
-Adicione um job ao `cd.yml` para deploy automático:
-
-```yaml
-deploy-staging:
-  name: Deploy to Staging
-  needs: docker
-  runs-on: ubuntu-latest
-  environment: staging       # GitHub Environment com proteção
-  steps:
-    - name: Deploy to staging server
-      run: |
-        # Exemplo com SSH
-        ssh user@staging-server \
-          "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest && \
-           docker compose -f compose.prod.yml up -d"
-```
-
-### 2. Deploy para produção com aprovação manual
-
-```yaml
-deploy-production:
-  name: Deploy to Production
-  needs: deploy-staging
-  runs-on: ubuntu-latest
-  environment:
-    name: production
-    url: https://api.dkfashion.com
-  steps:
-    - name: Deploy
-      run: echo "Deploy to production"
-```
-
-> Configure **Environment Protection Rules** no GitHub para exigir aprovação manual antes do deploy em produção.
-
-### 3. Smoke tests pós-deploy
-
-```yaml
-smoke-test:
-  name: Smoke Tests
-  needs: deploy-staging
-  runs-on: ubuntu-latest
-  steps:
-    - name: Health check
-      run: |
-        curl --fail --retry 5 --retry-delay 10 \
-          https://staging-api.dkfashion.com/api/health
-```
-
-### 4. Notificações
-
-```yaml
-notify:
-  name: Notify Team
-  needs: docker
-  if: always()
-  runs-on: ubuntu-latest
-  steps:
-    - name: Notify on Discord/Slack
-      uses: sarisia/actions-status-discord@v1
-      with:
-        webhook: ${{ secrets.DISCORD_WEBHOOK }}
-        status: ${{ job.status }}
-```
-
-### 5. Multi-platform builds
-
-Para suportar ARM (ex: AWS Graviton):
-
-```yaml
-- name: Build and push
-  uses: docker/build-push-action@v6
-  with:
-    platforms: linux/amd64,linux/arm64  # Multi-arch
-    # ... demais configurações
-```
-
-### 6. Vulnerability scanning
-
-```yaml
-- name: Scan image for vulnerabilities
-  uses: aquasecurity/trivy-action@master
-  with:
-    image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-    format: 'sarif'
-    output: 'trivy-results.sarif'
-```
-
----
-
-## 11. Referências
-
-| Recurso | Link |
-|---|---|
-| GitHub Actions — workflow_run | https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run |
-| Docker Build Push Action | https://github.com/docker/build-push-action |
-| GHCR Documentation | https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry |
-| Docker Multi-stage Builds | https://docs.docker.com/build/building/multi-stage/ |
-| GitHub Actions Cache (GHA) | https://docs.docker.com/build/cache/backends/gha/ |
-| OCI Image Spec | https://github.com/opencontainers/image-spec |
-
----
-
-> **Última atualização:** Maio 2026
-> **Mantido por:** Equipe DK Fashion — TPPE 2026/1
+| Action | Versao | Proposito |
+|---|---|---|
+| `actions/checkout` | v4 | Checkout do codigo |
+| `docker/setup-buildx-action` | v3 | Buildx com cache avancado |
+| `docker/login-action` | v3 | Autenticacao no GHCR |
+| `docker/metadata-action` | v5 | Tags e labels OCI automaticos |
+| `docker/build-push-action` | v6 | Build e push da imagem |

--- a/docs/cd.md
+++ b/docs/cd.md
@@ -1,0 +1,483 @@
+# Continuous Delivery (CD) — MarketPlace Backend
+
+> Documentação completa do pipeline de Continuous Delivery do projeto MarketPlace Backend (DK Fashion).
+
+---
+
+## Sumário
+
+- [1. O que é o CD implementado](#1-o-que-é-o-cd-implementado)
+- [2. Diferença entre CI e CD](#2-diferença-entre-ci-e-cd)
+- [3. Fluxo do Pipeline](#3-fluxo-do-pipeline)
+- [4. Quando o Build/Deploy ocorre](#4-quando-o-builddeploy-ocorre)
+- [5. Tecnologias utilizadas](#5-tecnologias-utilizadas)
+- [6. Estrutura do Workflow](#6-estrutura-do-workflow)
+- [7. Docker — Explicação detalhada](#7-docker--explicação-detalhada)
+- [8. Triggers do GitHub Actions](#8-triggers-do-github-actions)
+- [9. Como executar localmente](#9-como-executar-localmente)
+- [10. Como evoluir o pipeline](#10-como-evoluir-o-pipeline)
+- [11. Referências](#11-referências)
+
+---
+
+## 1. O que é o CD implementado
+
+O pipeline de **Continuous Delivery** automatiza o processo de empacotamento da aplicação em uma imagem Docker de produção e sua publicação no **GitHub Container Registry (GHCR)**.
+
+O CD **não duplica** responsabilidades do CI — ele assume que o código já foi validado (lint, typecheck, testes, coverage) e se concentra exclusivamente na entrega do artefato final.
+
+### O que o CD faz
+
+| Etapa | Descrição |
+|---|---|
+| **Gate** | Verifica se o CI concluiu com sucesso |
+| **Docker Build** | Constrói a imagem de produção com multi-stage build |
+| **Push para GHCR** | Publica a imagem com tags semânticas |
+| **Resumo** | Gera um summary no GitHub Actions com os detalhes da publicação |
+
+---
+
+## 2. Diferença entre CI e CD
+
+```mermaid
+graph LR
+    subgraph CI["🔍 CI — Continuous Integration"]
+        A[Lint + Typecheck] --> B[Build]
+        B --> C[Testes Unitários]
+        C --> D[Coverage + Integração]
+    end
+
+    subgraph CD["🚀 CD — Continuous Delivery"]
+        E[CI Gate] --> F[Docker Build]
+        F --> G[Push GHCR]
+    end
+
+    CI -->|sucesso na main| CD
+```
+
+| Aspecto | CI | CD |
+|---|---|---|
+| **Objetivo** | Validar qualidade do código | Empacotar e entregar artefato |
+| **Quando executa** | Push e PR em `dev` e `main` | Somente após CI bem-sucedido na `main` |
+| **O que verifica** | Lint, types, testes, coverage | — |
+| **O que produz** | Relatório de coverage | Imagem Docker publicada |
+| **Falha significa** | Código com problemas | Falha no empacotamento |
+
+> **Princípio:** O CI é o guardião da qualidade. O CD é o entregador — ele confia no CI.
+
+---
+
+## 3. Quando o Build/Deploy ocorre
+
+O CD é acionado **exclusivamente** quando:
+
+1. Um **push** é feito na branch `main`
+2. O **CI completa com sucesso** para esse push
+3. O GitHub Actions dispara o evento `workflow_run`
+
+### Cenários
+
+| Cenário | CI roda? | CD roda? |
+|---|---|---|
+| Push na `dev` | ✅ | ❌ |
+| PR para `main` | ✅ | ❌ |
+| Push na `main` + CI falha | ✅ | ❌ |
+| Push na `main` + CI passa | ✅ | ✅ |
+| Tag semver na `main` + CI passa | ✅ | ✅ (com tags de versão) |
+
+### Tags geradas na imagem
+
+| Tipo | Exemplo | Quando |
+|---|---|---|
+| `latest` | `ghcr.io/org/repo:latest` | Todo push na `main` |
+| `sha-*` | `ghcr.io/org/repo:sha-a1b2c3d` | Todo push na `main` |
+| `semver` | `ghcr.io/org/repo:1.2.3` | Quando há tag git `v1.2.3` |
+
+---
+
+## 4. Tecnologias utilizadas
+
+| Tecnologia | Propósito | Versão |
+|---|---|---|
+| **GitHub Actions** | Plataforma de CI/CD | v2 (workflow syntax) |
+| **Docker** | Containerização da aplicação | Buildx multi-platform |
+| **GHCR** | Registry de imagens Docker | Integrado ao GitHub |
+| **Node.js** | Runtime da aplicação | 22-alpine |
+| **pnpm** | Gerenciador de pacotes | 10.33.0 |
+| **NestJS** | Framework backend | Dockerfile multi-stage |
+
+### Actions utilizadas
+
+| Action | Versão | Propósito |
+|---|---|---|
+| `actions/checkout` | v4 | Checkout do código |
+| `docker/setup-buildx-action` | v3 | Setup do Buildx para cache avançado |
+| `docker/login-action` | v3 | Autenticação no GHCR |
+| `docker/metadata-action` | v5 | Geração automática de tags e labels |
+| `docker/build-push-action` | v6 | Build e push da imagem |
+
+---
+
+## 5. Estrutura do Workflow
+
+```yaml
+# Estrutura simplificada do cd.yml
+name: CD
+
+on:
+  workflow_run:           # Trigger encadeado
+    workflows: ["CI"]     # Nome exato do CI
+    types: [completed]    # Quando CI finaliza
+    branches: [main]      # Somente na main
+
+permissions:
+  contents: read          # Checkout
+  packages: write         # Push GHCR
+
+jobs:
+  gate:                   # Verifica se CI passou
+    if: conclusion == 'success'
+
+  docker:                 # Build + Push
+    needs: gate
+    steps:
+      - checkout          # SHA exato do CI
+      - setup-buildx      # Cache avançado
+      - login             # GHCR auth
+      - metadata          # Tags automáticas
+      - build-push        # Build + Push com cache
+      - summary           # Resumo no Actions
+```
+
+### Decisões Arquiteturais
+
+#### Por que `workflow_run` em vez de `needs` no mesmo arquivo?
+
+```mermaid
+graph TD
+    subgraph Opção_A["❌ Opção A: Tudo em ci.yml"]
+        A1[lint] --> A2[build]
+        A2 --> A3[test]
+        A3 --> A4[docker]
+        style A4 fill:#d32f2f,color:#fff
+    end
+    
+    subgraph Opção_B["✅ Opção B: workflow_run (escolhida)"]
+        B1["ci.yml (lint, build, test)"]
+        B2["cd.yml (docker)"]
+        B1 -->|workflow_run| B2
+    end
+```
+
+| Critério | Mesmo arquivo | `workflow_run` (escolhido) |
+|---|---|---|
+| Separação de responsabilidades | ❌ Misturado | ✅ Limpo |
+| CI roda em PRs sem acionar CD | ❌ Precisa de condicionais | ✅ Natural |
+| Permissões | ⚠️ Precisa de `packages:write` no CI | ✅ Cada um com suas permissões |
+| Evolução independente | ❌ Acoplado | ✅ Independente |
+
+#### Por que cache GHA (GitHub Actions) para Docker?
+
+- O cache `type=gha` usa o storage nativo do GitHub Actions
+- Não precisa de registry externo para cache
+- `mode=max` exporta todas as layers intermediárias para máximo reaproveitamento
+- Builds subsequentes são significativamente mais rápidos
+
+---
+
+## 6. Docker — Explicação detalhada
+
+### Multi-stage Build
+
+O Dockerfile utiliza um build multi-stage com 5 estágios:
+
+```mermaid
+graph TD
+    A["base<br/>Node 22-alpine + corepack"] --> B["deps<br/>pnpm install (todas deps)"]
+    A --> C["prod-deps<br/>pnpm install --prod"]
+    B --> D["dev<br/>Ambiente de desenvolvimento"]
+    B --> E["build<br/>nest build → dist/"]
+    C --> F["runner<br/>Imagem final de produção"]
+    E --> F
+    
+    style F fill:#1565c0,color:#fff,stroke-width:3px
+```
+
+| Estágio | Propósito | Presente na imagem final? |
+|---|---|---|
+| `base` | Imagem base com Node.js e corepack | Sim (base) |
+| `deps` | Instala todas as dependências | Não |
+| `dev` | Ambiente de desenvolvimento | Não |
+| `prod-deps` | Instala apenas deps de produção | Sim (node_modules) |
+| `build` | Compila TypeScript → JavaScript | Sim (dist/) |
+| **`runner`** | **Imagem final otimizada** | **Sim** |
+
+### Imagem Final (`runner`)
+
+A imagem de produção contém apenas:
+
+```
+/app
+├── dist/           # Código compilado (JavaScript)
+├── node_modules/   # Apenas dependências de produção
+└── package.json    # Metadados do pacote
+```
+
+**Características de segurança:**
+
+- Roda como usuário não-root (`nestjs:nodejs`)
+- Base Alpine (superfície de ataque mínima)
+- Healthcheck embutido (endpoint `/api/health`)
+- Sem código-fonte TypeScript, testes ou ferramentas de dev
+
+### Docker Compose — Ambientes
+
+| Arquivo | Ambiente | Target | Uso |
+|---|---|---|---|
+| `compose.dev.yml` | Desenvolvimento | `dev` | Hot-reload, volumes, debug |
+| `compose.prod.yml` | Produção | `runner` | Imagem otimizada, sem volumes |
+
+---
+
+## 7. Triggers do GitHub Actions
+
+### CI — Triggers
+
+```yaml
+on:
+  pull_request:
+    branches: [dev, main]    # Valida PRs antes do merge
+  push:
+    branches: [dev, main]    # Valida pushes diretos
+```
+
+### CD — Trigger
+
+```yaml
+on:
+  workflow_run:
+    workflows: ["CI"]        # Encadeia com o CI
+    types: [completed]       # Quando o CI finaliza (sucesso ou falha)
+    branches: [main]         # Somente na branch main
+```
+
+> **Importante:** O `workflow_run` dispara quando o CI **finaliza** (não necessariamente com sucesso). Por isso o job `gate` verifica explicitamente `conclusion == 'success'`.
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant GH as GitHub
+    participant CI as CI Workflow
+    participant CD as CD Workflow
+    participant GHCR as GHCR Registry
+    
+    Dev->>GH: git push main
+    GH->>CI: Trigger: push event
+    CI->>CI: lint + typecheck
+    CI->>CI: build
+    CI->>CI: test + coverage
+    CI-->>GH: ✅ Conclusion: success
+    GH->>CD: Trigger: workflow_run (completed)
+    CD->>CD: Gate: verifica conclusion == success
+    CD->>CD: Docker build (multi-stage)
+    CD->>GHCR: Push imagem com tags
+    CD-->>GH: 📋 Summary com detalhes
+```
+
+---
+
+## 8. Como executar localmente
+
+### Pré-requisitos
+
+- Docker Desktop ou Docker Engine instalado
+- Acesso ao repositório
+
+### Build local da imagem de produção
+
+```bash
+# Build simples da imagem de produção
+docker build --target runner -t marketplace-backend:local .
+
+# Build com verificação de sintaxe do Dockerfile
+docker build . --check
+
+# Build via Makefile (recomendado)
+make prod-build
+```
+
+### Rodando a imagem localmente
+
+```bash
+# Via Docker direto
+docker run --rm -p 3000:3000 \
+  -e NODE_ENV=production \
+  -e PORT=3000 \
+  -e POSTGRES_HOST=host.docker.internal \
+  -e POSTGRES_PORT=5432 \
+  -e POSTGRES_USER=seu_user \
+  -e POSTGRES_PASSWORD=sua_senha \
+  -e POSTGRES_DB=seu_banco \
+  -e JWT_SECRET=$(openssl rand -base64 32) \
+  marketplace-backend:local
+
+# Via Docker Compose (recomendado)
+make prod-up
+```
+
+### Simulando o pipeline completo localmente
+
+```bash
+# 1. Rodar CI localmente
+make lint                    # Lint
+pnpm typecheck               # Typecheck
+pnpm build                   # Build
+pnpm test                    # Testes unitários
+pnpm test:cov                # Coverage
+
+# 2. Se tudo passou, buildar imagem Docker
+docker build --target runner -t marketplace-backend:local .
+
+# 3. Verificar que a imagem funciona
+docker run --rm marketplace-backend:local node -e "console.log('OK')"
+```
+
+### Testando com o act (GitHub Actions local)
+
+```bash
+# Instalar o act (https://github.com/nektos/act)
+# O act simula GitHub Actions localmente
+
+# Listar workflows disponíveis
+act -l
+
+# Rodar apenas o build Docker (sem push)
+act workflow_run -W .github/workflows/cd.yml --dryrun
+```
+
+---
+
+## 10. Como evoluir o pipeline
+
+### Próximos passos sugeridos
+
+```mermaid
+graph LR
+    A["Atual<br/>Build + Push GHCR"] --> B["Deploy Staging"]
+    B --> C["Smoke Tests"]
+    C --> D["Deploy Produção"]
+    D --> E["Monitoramento"]
+    
+    style A fill:#1565c0,color:#fff
+    style B fill:#7b1fa2,color:#fff
+    style C fill:#e65100,color:#fff
+    style D fill:#2e7d32,color:#fff
+    style E fill:#f57f17,color:#000
+```
+
+### 1. Deploy automático para staging
+
+Adicione um job ao `cd.yml` para deploy automático:
+
+```yaml
+deploy-staging:
+  name: Deploy to Staging
+  needs: docker
+  runs-on: ubuntu-latest
+  environment: staging       # GitHub Environment com proteção
+  steps:
+    - name: Deploy to staging server
+      run: |
+        # Exemplo com SSH
+        ssh user@staging-server \
+          "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest && \
+           docker compose -f compose.prod.yml up -d"
+```
+
+### 2. Deploy para produção com aprovação manual
+
+```yaml
+deploy-production:
+  name: Deploy to Production
+  needs: deploy-staging
+  runs-on: ubuntu-latest
+  environment:
+    name: production
+    url: https://api.dkfashion.com
+  steps:
+    - name: Deploy
+      run: echo "Deploy to production"
+```
+
+> Configure **Environment Protection Rules** no GitHub para exigir aprovação manual antes do deploy em produção.
+
+### 3. Smoke tests pós-deploy
+
+```yaml
+smoke-test:
+  name: Smoke Tests
+  needs: deploy-staging
+  runs-on: ubuntu-latest
+  steps:
+    - name: Health check
+      run: |
+        curl --fail --retry 5 --retry-delay 10 \
+          https://staging-api.dkfashion.com/api/health
+```
+
+### 4. Notificações
+
+```yaml
+notify:
+  name: Notify Team
+  needs: docker
+  if: always()
+  runs-on: ubuntu-latest
+  steps:
+    - name: Notify on Discord/Slack
+      uses: sarisia/actions-status-discord@v1
+      with:
+        webhook: ${{ secrets.DISCORD_WEBHOOK }}
+        status: ${{ job.status }}
+```
+
+### 5. Multi-platform builds
+
+Para suportar ARM (ex: AWS Graviton):
+
+```yaml
+- name: Build and push
+  uses: docker/build-push-action@v6
+  with:
+    platforms: linux/amd64,linux/arm64  # Multi-arch
+    # ... demais configurações
+```
+
+### 6. Vulnerability scanning
+
+```yaml
+- name: Scan image for vulnerabilities
+  uses: aquasecurity/trivy-action@master
+  with:
+    image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+    format: 'sarif'
+    output: 'trivy-results.sarif'
+```
+
+---
+
+## 11. Referências
+
+| Recurso | Link |
+|---|---|
+| GitHub Actions — workflow_run | https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run |
+| Docker Build Push Action | https://github.com/docker/build-push-action |
+| GHCR Documentation | https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry |
+| Docker Multi-stage Builds | https://docs.docker.com/build/building/multi-stage/ |
+| GitHub Actions Cache (GHA) | https://docs.docker.com/build/cache/backends/gha/ |
+| OCI Image Spec | https://github.com/opencontainers/image-spec |
+
+---
+
+> **Última atualização:** Maio 2026
+> **Mantido por:** Equipe DK Fashion — TPPE 2026/1


### PR DESCRIPTION
## What

Adds a CD pipeline that builds and publishes the production Docker image to GHCR after CI passes on `main`.

## Changes

| File | What changed |
|---|---|
| `.github/workflows/cd.yml` | New CD workflow (`workflow_run` chained off CI) |
| `docs/cd.md` | Documentation covering triggers, Docker multi-stage, cache strategy, and local testing |
| `Makefile` | New targets: `ci-local` (mirrors CI) and `docker-build` (mirrors CD) |

## How it works

- Triggers via `workflow_run` when CI completes on `main`
- `gate` job checks `conclusion == 'success'` before proceeding
- Builds Docker image using the existing multi-stage Dockerfile (target: `runner`)
- Pushes to GHCR with `latest`, `sha-<commit>`, and semver tags
- Uses GHA cache (`type=gha,mode=max`) for faster subsequent builds

## Design decisions

- **Separate workflow (`workflow_run`)** instead of adding jobs to `ci.yml` — keeps CI and CD decoupled with independent permissions and evolution
- **No changes to existing CI** — zero impact on the current pipeline
- **Minimal permissions** — `contents:read` + `packages:write` only

## How to test locally

```bash
make ci-local       # mirrors CI
make docker-build   # mirrors CD (docker build --target runner)
```

---

Pode copiar direto pro PR.