### PR TITLE
Hotfix/cicd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,9 +58,6 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             # Tag com SHA curto para rastreabilidade exata
             type=sha,prefix=sha-,format=short
-            # Tag semver se houver git tag (ex: v1.0.0 → 1.0.0, 1.0, 1)
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,3 +160,24 @@ jobs:
           name: coverage-report
           path: coverage/
           retention-days: 7
+
+  docker:
+    name: Docker image build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Valida que o estágio `runner` do Dockerfile builda (sem push). O CD
+      # publica a imagem no GHCR; aqui só garantimos que ela compila antes do
+      # merge. Espelha `make prod-image`.
+      - name: Build runner image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runner
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export COMPOSE_DOCKER_CLI_BUILD := 1
 	dev-lint dev-lint-fix dev-format dev-typecheck dev-check dev-openapi \
 	prod-up prod-down prod-logs prod-build prod-rebuild \
 	db-shell db-reset db-backup \
-	clean check ci-local docker-build
+	clean check dev-ci prod-image
 
 help:
 	@echo "Setup e local:"
@@ -67,8 +67,8 @@ help:
 	@echo "  make check            Verifica se o Dockerfile esta correto"
 	@echo ""
 	@echo "CI/CD:"
-	@echo "  make ci-local         Roda lint + typecheck + format:check + testes (espelha o CI)"
-	@echo "  make docker-build     Builda a imagem Docker de producao standalone (espelha o CD)"
+	@echo "  make dev-ci           Roda lint + typecheck + format:check + build + testes no container (espelha o CI)"
+	@echo "  make prod-image       Builda a imagem Docker de producao standalone (espelha o CD)"
 
 env-setup:
 	cp -n .env.development.example .env.development || true
@@ -209,12 +209,8 @@ clean:
 check:
 	docker build . --check
 
-ci-local:
-	pnpm lint
-	pnpm typecheck
-	pnpm format:check
-	pnpm build
-	pnpm test
+dev-ci:
+	$(COMPOSE_DEV) exec $(SERVICE) sh -c "pnpm lint && pnpm typecheck && pnpm format:check && pnpm build && pnpm test"
 
-docker-build:
+prod-image:
 	docker build --target runner -t marketplace-backend:local .


### PR DESCRIPTION
This pull request updates the CI/CD workflow and the `Makefile` to improve the Docker build process, ensure better alignment between local development and CI, and simplify build commands. The main changes include adding a Docker build check to CI, refactoring Makefile targets for clarity, and removing unused Docker image tags from the CD workflow.

**CI/CD Workflow Improvements:**

* Added a new `docker` job to `.github/workflows/ci.yml` that builds the Docker image (target `runner`) to ensure it compiles successfully before merging, mirroring the `make prod-image` process but without pushing the image.
* Removed semver-based Docker image tags from `.github/workflows/cd.yml` to simplify image tagging and avoid unnecessary tags.

**Makefile Refactoring:**

* Replaced the `ci-local` and `docker-build` targets with `dev-ci` (runs all checks and tests inside the dev container) and `prod-image` (builds the production Docker image), updating the help text accordingly for clarity. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L14-R14) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L70-R71) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L212-R215)