### PR TITLE
Dev

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,9 +58,6 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             # Tag com SHA curto para rastreabilidade exata
             type=sha,prefix=sha-,format=short
-            # Tag semver se houver git tag (ex: v1.0.0 → 1.0.0, 1.0, 1)
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,3 +160,24 @@ jobs:
           name: coverage-report
           path: coverage/
           retention-days: 7
+
+  docker:
+    name: Docker image build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Valida que o estágio `runner` do Dockerfile builda (sem push). O CD
+      # publica a imagem no GHCR; aqui só garantimos que ela compila antes do
+      # merge. Espelha `make prod-image`.
+      - name: Build runner image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runner
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export COMPOSE_DOCKER_CLI_BUILD := 1
 	dev-lint dev-lint-fix dev-format dev-typecheck dev-check dev-openapi \
 	prod-up prod-down prod-logs prod-build prod-rebuild \
 	db-shell db-reset db-backup \
-	clean check ci-local docker-build
+	clean check dev-ci prod-image
 
 help:
 	@echo "Setup e local:"
@@ -67,8 +67,8 @@ help:
 	@echo "  make check            Verifica se o Dockerfile esta correto"
 	@echo ""
 	@echo "CI/CD:"
-	@echo "  make ci-local         Roda lint + typecheck + format:check + testes (espelha o CI)"
-	@echo "  make docker-build     Builda a imagem Docker de producao standalone (espelha o CD)"
+	@echo "  make dev-ci           Roda lint + typecheck + format:check + build + testes no container (espelha o CI)"
+	@echo "  make prod-image       Builda a imagem Docker de producao standalone (espelha o CD)"
 
 env-setup:
 	cp -n .env.development.example .env.development || true
@@ -209,12 +209,8 @@ clean:
 check:
 	docker build . --check
 
-ci-local:
-	pnpm lint
-	pnpm typecheck
-	pnpm format:check
-	pnpm build
-	pnpm test
+dev-ci:
+	$(COMPOSE_DEV) exec $(SERVICE) sh -c "pnpm lint && pnpm typecheck && pnpm format:check && pnpm build && pnpm test"
 
-docker-build:
+prod-image:
 	docker build --target runner -t marketplace-backend:local .


### PR DESCRIPTION
This pull request refactors the Docker build and CI/CD workflow to improve consistency between local development, CI, and CD processes. The main changes include updating Makefile targets to better reflect their purpose, ensuring Docker images are built in CI to catch build issues before merging, and simplifying Docker image tagging in the deployment workflow.

**CI/CD Workflow Improvements:**

* Added a new `docker` job to `.github/workflows/ci.yml` that builds the Docker `runner` image as part of CI, ensuring that the image compiles successfully before merging. This mirrors the `make prod-image` command but does not push the image.
* Removed semver-based Docker image tags from the CD workflow in `.github/workflows/cd.yml`, simplifying image tagging to use only `latest` and short SHA tags.

**Makefile Refactoring:**

* Replaced the `ci-local` and `docker-build` targets with `dev-ci` (runs lint, typecheck, format:check, build, and tests inside the dev container, mirroring CI) and `prod-image` (builds the production Docker image, mirroring CD). Updated the help text accordingly. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L14-R14) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L70-R71) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L212-R215)