### PR TITLE
feat: integracao com SonarCloud (closes #68)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,27 @@ jobs:
           path: coverage/
           retention-days: 7
 
+  sonarcloud:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: coverage
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   docker:
     name: Docker image build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ package-lock.json
 .demo-backend.log
 coverage
 openapi.json
+.scannerwork

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -531,6 +531,7 @@ ESLint só impõe `no-magic-numbers` em services/controllers — `entities/`, `d
 | `build` | `pnpm build` (verifica compilação TS) |
 | `test-unit` | `pnpm test` (specs com mocks, sem banco) — feedback rápido |
 | `coverage` | `pnpm test:cov` (unit + integração) com Postgres 16 como service; falha se a cobertura cair abaixo do `coverageThreshold`. Sobe o relatório como artefato `coverage-report`. |
+| `sonarcloud` | Baixa o `coverage-report` do job `coverage` e roda a análise estática do [SonarCloud](https://sonarcloud.io) (org `tppe-2026-1-marketplace`), consumindo `coverage/lcov.info`. Config em `sonar-project.properties`. Requer o secret `SONAR_TOKEN` no repositório. |
 
 Tempo esperado total: ~3min.
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+sonar.organization=tppe-2026-1-marketplace
+sonar.projectKey=TPPE-2026-1-Marketplace_MarketPlace-Backend
+sonar.projectName=MarketPlace-Backend
+
+sonar.sources=src
+sonar.tests=src
+sonar.test.inclusions=**/*.spec.ts,**/*.integration.ts
+sonar.exclusions=**/*.spec.ts,**/*.integration.ts,**/migrations/**
+sonar.sourceEncoding=UTF-8
+
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
## Summary
- Adiciona `sonar-project.properties` (org `tppe-2026-1-marketplace`, project key `TPPE-2026-1-Marketplace_MarketPlace-Backend`)
- Adiciona job `sonarcloud` ao workflow de CI, reaproveitando o relatorio de cobertura (`coverage/lcov.info`) gerado pelo job `coverage`
- Ignora `.scannerwork/` e documenta o novo job no CLAUDE.md

## Test plan
- [x] `SONAR_TOKEN` configurado como secret no repositorio
- [x] Verificar que o job `sonarcloud` roda com sucesso no CI deste PR
- [x] Confirmar que o projeto aparece no dashboard do SonarCloud apos o primeiro scan