### PR TITLE
fix: corrige caminho de saída do parser.py no workflow de métricas

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -32,7 +32,7 @@ def save_sonar_metrics(tag):
  
     print("Extração do Sonar concluída.")
  
-    file_path = f'./qa-analytics/analytics-raw-data/TPPE-2026.1-Marketplace-{REPO}-{TODAY.strftime("%m-%d-%Y-%H-%M-%S")}-{tag}.json'
+    file_path = f'./analytics-raw-data/TPPE-2026.1-Marketplace-{REPO}-{TODAY.strftime("%m-%d-%Y-%H-%M-%S")}-{tag}.json'
  
     with open(file_path, 'w') as fp:
         fp.write(json.dumps(j))
@@ -69,7 +69,7 @@ def save_github_metrics_runs():
  
     print("Quantidade de workflow_runs: " + str(len(data["workflow_runs"])))
  
-    file_path = f'./qa-analytics/analytics-raw-data/GitHub_API-Runs-TPPE-2026.1-Marketplace-{REPO}-{TODAY.strftime("%m-%d-%Y-%H-%M-%S")}.json'
+    file_path = f'./analytics-raw-data/GitHub_API-Runs-TPPE-2026.1-Marketplace-{REPO}-{TODAY.strftime("%m-%d-%Y-%H-%M-%S")}.json'
  
     # Salva os dados em um json file
     with open(file_path, 'w') as fp:
@@ -101,7 +101,7 @@ def save_github_metrics_issues():
  
     print("Quantidade total de issues: " + str(len(issues)))
  
-    file_path = f'./qa-analytics/analytics-raw-data/GitHub_API-Issues-TPPE-2026.1-Marketplace-{REPO}.json'
+    file_path = f'./analytics-raw-data/GitHub_API-Issues-TPPE-2026.1-Marketplace-{REPO}.json'
  
     # Salvar todas as issues em um arquivo JSON
     with open(file_path, 'w') as fp:


### PR DESCRIPTION
## Resumo
- O `parser.py` escrevia os arquivos de métricas em `./qa-analytics/analytics-raw-data/`, diretório que só é criado depois (no clone do repo de documentação, no step "Envia métricas para repo de Doc").
- O workflow cria e lê de `./analytics-raw-data/` (steps "Criar diretório" e "Envia métricas para repo de Doc"), causando `FileNotFoundError` no step "Coletar métricas no SonarCloud".
- Corrige as 3 ocorrências do caminho em `parser.py` para `./analytics-raw-data/`.

Erro original: https://github.com/TPPE-2026-1-Marketplace/MarketPlace-Backend/actions/runs/34544833844

## Test plan
- [ ] Confirmar que o workflow "Export de métricas" passa após o merge em `dev`