### PR TITLE
fix: corrige diretório de trabalho do step de envio de métricas

### DIFF
--- a/.github/workflows/qa-metrics.yml
+++ b/.github/workflows/qa-metrics.yml
@@ -25,9 +25,9 @@ jobs:
           git config --global user.email "${{secrets.USER_EMAIL}}"
           git config --global user.name "${{secrets.USER_NAME}}"
           git clone --single-branch --branch main "https://x-access-token:${{secrets.API_TOKEN_DOC}}@github.com/TPPE-2026-1-Marketplace/documentacao.git" doc
-          mkdir -p qa-analytics/Analytics/data
-          cp -R analytics-raw-data/*.json qa-analytics/Analytics/data
-          cd qa-analytics/
+          mkdir -p doc/qa-analytics/Analytics/data
+          cp -R analytics-raw-data/*.json doc/qa-analytics/Analytics/data
+          cd doc/qa-analytics/
           git add .
           git commit -m "Adicionando métricas do repositório ${{ github.event.repository.name }} ${{ github.ref_name }}"
           git push


### PR DESCRIPTION
## Resumo
- Segundo bug encontrado após o merge do #175 (que corrigiu o `parser.py`): o job "Coletar métricas no SonarCloud" passou a funcionar, mas o step seguinte "Envia métricas para repo de Doc" falhava com `403 Permission denied` ao tentar `git push`.
- Causa: faltava um `cd doc` após o `git clone ... doc`. O `mkdir -p qa-analytics/...` e o `cd qa-analytics/` rodavam na raiz do checkout do próprio repositório (Backend), não dentro do clone de `documentacao`. Como resultado, `git add/commit/push` operavam no repo errado — tentando dar push em `MarketPlace-Backend.git` com o `GITHUB_TOKEN` padrão do job, que não tem permissão de escrita (branch `dev` é protegida).
- Corrige apontando os 3 comandos para dentro de `doc/qa-analytics/...`.

## Pendência (fora do escopo deste PR)
- O secret `API_TOKEN_DOC` (usado no `git clone`/`git push` para `documentacao`) não está configurado neste repositório nem no Frontend. Como `documentacao` é público, o `clone` funciona sem ele, mas o `git push` final vai falhar por falta de autenticação até que um PAT com permissão de escrita em `documentacao` seja criado e adicionado como secret `API_TOKEN_DOC` em ambos os repos.

Runs relacionadas:
- https://github.com/TPPE-2026-1-Marketplace/MarketPlace-Backend/actions/runs/34544833844 (erro original no parser.py)
- https://github.com/TPPE-2026-1-Marketplace/MarketPlace-Backend/actions/runs/34547096730 (erro atual: 403 no push)

## Test plan
- [ ] Confirmar que o workflow "Export de métricas" chega até o `git push` sem erro de diretório após o merge (ainda vai falhar em `git push` até o `API_TOKEN_DOC` ser configurado)