### PR TITLE
fix: corrige identificador da org/projeto usado nas chamadas de API

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -22,8 +22,8 @@ METRICS_SONAR = [
     'reliability_rating',
 ]
  
-BASE_URL_SONAR = 'https://sonarcloud.io/api/measures/component_tree?component=TPPE-2026.1-Marketplace_'
-OWNER = "TPPE-2026.1-Marketplace"
+BASE_URL_SONAR = 'https://sonarcloud.io/api/measures/component_tree?component=TPPE-2026-1-Marketplace_'
+OWNER = "TPPE-2026-1-Marketplace"
  
 def save_sonar_metrics(tag):
     response = requests.get(f'{BASE_URL_SONAR}{REPO}&metricKeys={",".join(METRICS_SONAR)}&ps=500')


### PR DESCRIPTION
## Resumo
- `BASE_URL_SONAR` e `OWNER` em `parser.py` usavam `TPPE-2026.1-Marketplace` (com ponto entre `2026` e `1`).
- A org real no GitHub e a `projectKey` real no SonarCloud (ver `sonar-project.properties`) usam hífen: `TPPE-2026-1-Marketplace`.
- Resultado: a chamada ao SonarCloud retornava `"Component key 'TPPE-2026.1-Marketplace_MarketPlace-Backend' not found"` — o JSON salvo em `qa-analytics/Analytics/data/` no repo `documentacao` continha só esse erro, nenhuma métrica real. As chamadas à API de issues/runs do GitHub também batiam 404 pelo mesmo motivo.
- Confirmado manualmente que a URL corrigida (`https://sonarcloud.io/api/measures/component_tree?component=TPPE-2026-1-Marketplace_MarketPlace-Backend`) retorna dados reais.
- Isso é uma causa raiz do dashboard Streamlit (`documentacao/qa-analytics/dashboard.py`) mostrar "Nenhum dado do SonarCloud encontrado em `data/`" — há também um bug separado no próprio dashboard (glob/regex incompatíveis com o nome real dos arquivos), que será corrigido em PR separado no repo `documentacao`.

## Test plan
- [ ] Após merge, rodar o workflow "Export de métricas" e conferir que o JSON salvo em `documentacao` tem métricas reais (não `{"errors": [...]}`)